### PR TITLE
Add initial implementation of <vaadin-month-calendar>

### DIFF
--- a/demo/month-calendar.html
+++ b/demo/month-calendar.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title></title>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
+    <link rel="import" href="../vaadin-month-calendar.html">
+  </head>
+  <body>
+    <!-- Simple test page, to be removed later. -->
+    <vaadin-month-calendar></vaadin-month-calendar>
+    <vaadin-month-calendar></vaadin-month-calendar>
+    <vaadin-month-calendar month="2016-01-01" value="2016-01-31"></vaadin-month-calendar>
+    <vaadin-month-calendar month="2016-02-01"></vaadin-month-calendar>
+    <vaadin-month-calendar month="2016-03-01"></vaadin-month-calendar>
+  </body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,8 @@
 <body>
   <script>
     WCT.loadSuites([
-      'overlay.html'
+      'overlay.html',
+      'month-calendar.html'
     ]);
   </script>
 </body>

--- a/test/month-calendar.html
+++ b/test/month-calendar.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>vaadin-month-calendar basic tests</title>
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+    <link rel="import" href="../vaadin-month-calendar.html">
+  </head>
+  <body>
+    <test-fixture id="vaadin-month-calendar">
+      <template>
+        <vaadin-month-calendar></vaadin-month-calendar>
+      </template>
+    </test-fixture>
+    <test-fixture id="vaadin-month-calendar-2016">
+      <template>
+        <vaadin-month-calendar month="2016-01-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-02-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-03-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-04-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-05-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-06-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-07-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-08-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-09-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-10-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-11-01"></vaadin-month-calendar>
+        <vaadin-month-calendar month="2016-12-01"></vaadin-month-calendar>
+      </template>
+    </test-fixture>
+
+    <script>
+      function tap(element) {
+        Polymer.Base.fire('tap', {}, {
+          bubbles: true,
+          node: element
+        });
+      }
+
+      describe('vaadin-month-calendar', function() {
+        var monthCalendar;
+
+        beforeEach(function(done) {
+          monthCalendar = fixture('vaadin-month-calendar');
+          monthCalendar.month = new Date(2016, 1, 1); // Feb 2016
+
+          valueChangedSpy = sinon.spy();
+          monthCalendar.addEventListener('value-changed', valueChangedSpy);
+
+          // Need to wait for the templates to be rendered.
+          Polymer.Base.async(done);
+        });
+
+        it('should render correct number of days for 2016', function(done) {
+          var year2016 = fixture('vaadin-month-calendar-2016');
+          Polymer.Base.async(function() {
+            var monthLenghts = year2016.map(function(month) {
+              return month.$.monthGrid.querySelectorAll('div:not(.weekday):not(:empty)').length;
+            });
+            expect(monthLenghts).to.eql([31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]);
+            done();
+          });
+        });
+
+        it('should render days in correct order by default', function() {
+          var weekdays = monthCalendar.$.monthGrid.querySelectorAll('div.weekday');
+          var weekdayTitles = Array.prototype.map.call(weekdays, function(weekday) {
+            return weekday.textContent;
+          });
+          expect(weekdayTitles).to.eql(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
+        });
+
+        it('should render days in correct order by first day of week', function(done) {
+          monthCalendar._firstDayOfWeek = 1; // Start from Monday.
+
+          Polymer.Base.async(function() {
+            var weekdays = monthCalendar.$.monthGrid.querySelectorAll('div.weekday');
+            var weekdayTitles = Array.prototype.map.call(weekdays, function(weekday) {
+              return weekday.textContent;
+            });
+            expect(weekdayTitles).to.eql(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+            done();
+          });
+        });
+
+        it('should re-render after changing the month', function(done) {
+          monthCalendar.month = new Date(2000, 0, 1); // Feb 2016 -> Jan 2000
+          Polymer.Base.async(function() {
+            var days = monthCalendar.$.monthGrid.querySelectorAll('div:not(.weekday):not(:empty)').length;
+            expect(days).to.equal(31);
+            expect(monthCalendar.$.title.textContent).to.equal('January');
+            done();
+          });
+        });
+
+        it('should fire value change on tap', function() {
+          var dateElements = monthCalendar.$.monthGrid.querySelectorAll('div:not(.weekday):not(:empty)');
+          for (var i = 0; i < dateElements.length; i++) {
+            if (dateElements[i].date.getDate() === 10) {
+              // Tenth of February.
+              tap(dateElements[i]);
+            }
+          }
+          expect(valueChangedSpy.callCount).to.equal(1);
+        });
+
+        it('should update value on tap', function() {
+          var dateElements = monthCalendar.$.monthGrid.querySelectorAll('div:not(.weekday):not(:empty)');
+          for (var i = 0; i < dateElements.length; i++) {
+            if (dateElements[i].date.getDate() === 10) {
+              // Tenth of February.
+              tap(dateElements[i]);
+            }
+          }
+          expect(monthCalendar.value.getFullYear()).to.equal(2016);
+          expect(monthCalendar.value.getMonth()).to.equal(1);
+          expect(monthCalendar.value.getDate()).to.equal(10);
+        });
+      });
+    </script>
+
+  </body>
+</html>

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-list/iron-list.html">
+<link rel="import" href="vaadin-month-calendar.html">
 
 <dom-module id="vaadin-date-picker-overlay">
   <template>
@@ -39,9 +40,7 @@
     <div id="scroller">
       <iron-list id="list" items="[[_months]]" as="monthIndex" on-scroll="_onListScroll">
         <template>
-          <div class="item" month="[[_dateAfterXMonths(_originDate, monthIndex)]]">
-            [[_dateAfterXMonths(_originDate, monthIndex)]]
-          </div>
+          <vaadin-month-calendar class="item" month="[[_dateAfterXMonths(_originDate, monthIndex)]]"></vaadin-month-calendar>
         </template>
       </iron-list>
     </div>

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -1,0 +1,152 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="vaadin-month-calendar">
+  <template>
+    <style>
+      :host {
+        display: block;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+      #title {
+        text-align: center;
+      }
+      #monthGrid {
+        display: flex;
+        flex-wrap: wrap;
+      }
+      #monthGrid div {
+        text-align: center;
+        width: 14.285714286%;
+        box-sizing: border-box;
+        cursor: pointer;
+      }
+      #monthGrid div.weekday {
+        text-transform: uppercase;
+        font-size: 80%;
+        color: #999;
+        cursor: default;
+      }
+      #monthGrid div[today] {
+        border: 1px solid red;
+      }
+      #monthGrid div[selected] {
+        color: red;
+      }
+    </style>
+
+    <div id="title">[[_getTitle(month, _monthNames)]]</div>
+    <div id="monthGrid" on-tap="_handleTap">
+      <template is="dom-repeat" items="[[_getWeekDayNames(_weekDayNames, _firstDayOfWeek)]]">
+        <div class="weekday">[[item]]</div>
+      </template>
+      <template is="dom-repeat" items="[[_getDays(month, _firstDayOfWeek)]]">
+        <div today$="[[_isToday(item)]]" selected$="[[_isSelected(item, value)]]" date="[[item]]">[[_getDate(item)]]</div>
+      </template>
+    </div>
+  </template>
+  <script>
+    Polymer({
+      is: 'vaadin-month-calendar',
+
+      properties: {
+
+        /**
+         * A `Date` object defining the month to be displayed. Only year and
+         * month properties are actually used.
+         */
+        month: {
+          type: Date,
+          value: new Date()
+        },
+
+        /**
+         * A `Date` object for the currently selected date.
+         */
+        value: {
+          type: Date,
+          notify: true
+        },
+
+        _monthNames: {
+          value: [
+            'January', 'February', 'March', 'April', 'May', 'June', 'July',
+            'August', 'September', 'October','November', 'December'
+          ]
+        },
+
+        _weekDayNames: {
+          value: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+        },
+
+        _firstDayOfWeek: {
+          type: Number,
+          value: 0
+        }
+      },
+
+      _getTitle: function(month) {
+        return this._monthNames[month.getMonth()];
+      },
+
+      _dateEquals: function(date1, date2) {
+        if (date1 && date2) {
+          return date1.getFullYear() === date2.getFullYear() &&
+                 date1.getMonth() === date2.getMonth() &&
+                 date1.getDate() === date2.getDate();
+        } else {
+          return false;
+        }
+      },
+
+      _dateAdd: function(date, delta) {
+        date.setDate(date.getDate() + delta);
+      },
+
+      _getWeekDayNames: function(weekDayNames, firstDayOfWeek) {
+        return weekDayNames.slice(firstDayOfWeek).concat(weekDayNames.slice(0, firstDayOfWeek));
+      },
+
+      _getDate: function(date) {
+        return date.getMonth() === this.month.getMonth() ? date.getDate() : '';
+      },
+
+      _isSelected: function(date, value) {
+        return this._dateEquals(value, date);
+      },
+
+      _isToday: function(date) {
+        return this._dateEquals(new Date(), date);
+      },
+
+      _getDays: function() {
+        // First day of the month (at noon).
+        var date = new Date(this.month.getFullYear(), this.month.getMonth(), 1, 12, 0, 0);
+
+        // Rewind to first day of the week.
+        while (date.getDay() !== this._firstDayOfWeek) {
+          this._dateAdd(date, -1);
+        }
+
+        var days = [];
+        var startMonth = date.getMonth();
+        while (date.getMonth() === this.month.getMonth() || date.getMonth() === startMonth) {
+          days.push(new Date(date));
+
+          // Advance to next day.
+          this._dateAdd(date, 1);
+        }
+        return days;
+      },
+
+      _handleTap: function(e) {
+        if (e.target.date) {
+          this.value = e.target.date;
+        }
+      }
+
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
Alternative version to https://github.com/vaadin/vaadin-date-picker/pull/7 implemented with `dom-repeat` templates.

Connects to #4  

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/9)
<!-- Reviewable:end -->
