### PR TITLE
Add initial implementation of the year scroller

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -17,14 +17,17 @@ function monthsEqual(date1, date2) {
   return date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth();
 }
 
-function getFirstVisibleItem(scroller) {
+function getFirstVisibleItem(scroller, bufferOffset) {
   var children = [];
+  bufferOffset = (bufferOffset || 0);
+
   scroller._buffers.forEach(function(buffer) {
     [].forEach.call(buffer.children, function(itemWrapper) {
       children.push(itemWrapper);
     });
   });
+  var scrollerRect = scroller.getBoundingClientRect();
   return children.reduce(function(prev, current) {
-    return (Math.floor(current.getBoundingClientRect().top) - Math.floor(scroller.getBoundingClientRect().top) <= 0) ? current : prev;
+    return (Math.floor(current.getBoundingClientRect().top) - Math.floor(scrollerRect.top + bufferOffset) <= 0) ? current : prev;
   });
 }

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -49,7 +49,9 @@
             expect(dropdown.positionTarget).to.equal(fullscreen ? document.documentElement : datepicker);
             done();
           });
-          datepicker._open();
+          Polymer.Base.async(function() {
+            datepicker._open();
+          });
         });
 
       });

--- a/test/month-calendar.html
+++ b/test/month-calendar.html
@@ -8,7 +8,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="common.js"></script>
-  
+
   <link rel="import" href="../vaadin-month-calendar.html">
 </head>
 
@@ -89,7 +89,7 @@
       it('should render month name in correct locale', function(done) {
         monthCalendar.locale = 'fi';
         waitUntilLocaleAvailable('fi', function() {
-          expect(monthCalendar.$.title.textContent).to.equal('helmikuu');
+          expect(monthCalendar.$.title.textContent).to.equal('helmikuu 2016');
           done();
         });
       });
@@ -99,7 +99,7 @@
         Polymer.Base.async(function() {
           var days = monthCalendar.$.monthGrid.querySelectorAll('div:not(.weekday):not(:empty)').length;
           expect(days).to.equal(31);
-          expect(monthCalendar.$.title.textContent).to.equal('January');
+          expect(monthCalendar.$.title.textContent).to.equal('January 2000');
           done();
         });
       });

--- a/test/overlay.html
+++ b/test/overlay.html
@@ -23,8 +23,9 @@
     describe('vaadin-date-picker-overlay', function() {
       var overlay;
 
-      beforeEach(function() {
+      beforeEach(function(done) {
         overlay = fixture('overlay');
+        waitUntilScrolledTo(new Date(), done);
       });
 
       function waitUntilScrolledTo(date, callback) {
@@ -49,7 +50,18 @@
         var date = new Date(2000, 1, 1);
         overlay.scrollToDate(date);
         waitUntilScrolledTo(date, function() {
-          expect(monthsEqual(getFirstVisibleItem(overlay.$.scroller).firstElementChild.month, date)).to.be.true;
+          var offset = overlay.$.scroller.clientHeight / 2;
+          expect(monthsEqual(getFirstVisibleItem(overlay.$.scroller, offset).firstElementChild.month, date)).to.be.true;
+          done();
+        });
+      });
+
+      it('should scroll to the given year', function(done) {
+        var date = new Date(2000, 1, 1);
+        overlay.scrollToDate(date);
+        waitUntilScrolledTo(date, function() {
+          var offset = overlay.$.yearScroller.clientHeight / 2;
+          expect(getFirstVisibleItem(overlay.$.yearScroller, offset).firstElementChild.textContent).to.equal('2000');
           done();
         });
       });

--- a/test/scroller.html
+++ b/test/scroller.html
@@ -52,23 +52,32 @@
         expect(scroller.$$('.buffer').children).to.have.length(80);
       });
 
-      it('should reflect currently visible item index as position', function(done) {
-        var initialScrollTop = scroller.$.scroller.scrollTop;
-        var scrollDiff = scroller.itemHeight * scroller.bufferSize * 3;
-
+      it('should reflect currently visible item index as position scrolling down', function(done) {
         function scrollDown() {
-          scroller.removeEventListener('scroll', scrollDown);
           verifyPosition();
-          if (scroller.$.scroller.scrollTop >= initialScrollTop + scrollDiff) {
+          if (scroller.position > scroller.bufferSize * 1.5) {
             done();
           } else {
             scroller.$.scroller.scrollTop += scroller.itemHeight * 3.7;
-            scroller.async(scrollDown, 1);
+            scroller.async(scrollDown, 20);
           }
         }
 
-        scroller.addEventListener('scroll', scrollDown);
-        scroller.$.scroller.scrollTop = initialScrollTop - scrollDiff;
+        scrollDown();
+      });
+
+      it('should reflect currently visible item index as position scrolling up', function(done) {
+        function scrollUp() {
+          verifyPosition();
+          if (scroller.position < -scroller.bufferSize * 1.5) {
+            done();
+          } else {
+            scroller.$.scroller.scrollTop -= scroller.itemHeight * 3.7;
+            scroller.async(scrollUp, 20);
+          }
+        }
+
+        scrollUp();
       });
 
       it('should reflect position as currently visible item index', function() {

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -1,6 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../paper-styles/shadow.html">
 <link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../iron-icon/iron-icon.html">
+<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="vaadin-month-calendar.html">
 <link rel="import" href="vaadin-infinite-scroller.html">
 
@@ -11,6 +13,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
+        width: 100%;
         background: #fff;
         font: inherit;
         @apply(--paper-font-common-base);
@@ -18,23 +21,168 @@
       }
 
       #toolbar {
+        cursor: pointer;
         padding: 1em;
-        background: #eee;
+        background: #fff;
+        z-index: 2;
+        @apply(--paper-font-button);
         @apply(--shadow-elevation-2dp);
       }
 
-      #scroller {
+      #toolbar:not([desktop]) {
+        color: #03a9f4;
+      }
+
+      #toolbar iron-icon {
+        fill: #03a9f4;
+        padding: 0px;
+        position: absolute;
+        right: 1em;
+        transition: transform 200ms;
+        --iron-icon-width: 20px;
+        --iron-icon-height: 20px;
+      }
+
+      #toolbar iron-icon[rotate] {
+        transform: rotate(180deg);
+      }
+
+      #toolbar iron-icon[hidden] {
+        display: none;
+      }
+
+      #scrollers {
+        display: flex;
+        flex-direction: row;
         height: 100%;
+        width: 100%;
+        position: relative;
+        overflow: hidden;
+      }
+
+      #scrollers #fade {
+        pointer-events: none;
+        display: block;
+        background: linear-gradient(90deg, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0));
+        width: 50px;
+        position: absolute;
+        height: 100%;
+        z-index: 1;
+      }
+
+      #scrollers[desktop] #fade {
+        display: none;
+      }
+
+      #scroller,
+      #yearScroller {
+        height: 100%;
+      }
+
+      #scroller {
+        padding: 0 8px;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
+
+      #scrollers[desktop] #scroller {
+        right: 50px;
+      }
+
+      #yearScroller {
+        text-align: center;
+        width: 50px;
+        background: #444;
+        color: #d2d2d2;
+        cursor: pointer;
+        position: absolute;
+        right: 0;
+        transform: translateX(100%);
+        -webkit-tap-highlight-color: transparent;
+        @apply(--paper-font-menu);
+      }
+
+      #yearScroller div {
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+      }
+
+      #scrollers[desktop] #yearScroller {
+        position: absolute;
+        transform: none !important;
+      }
+
+      #scroller {
+        /* Center the month scroller position. */
+        --vaadin-infinite-scroller-buffer: {
+          top: 50%;
+          margin-top: -125px;
+        }
+      }
+
+      #yearScroller {
+        /* Center the year scroller position. */
+        --vaadin-infinite-scroller-buffer: {
+          top: 50%;
+          margin-top: -1.6em;
+        }
+      }
+
+      #yearScroller:before {
+        content: '';
+        display: block;
+        background: transparent;
+        width: 0px;
+        height: 0px;
+        position: absolute;
+        left: 0;
+        top: 50%;
+        margin-top: -6px;
+        border-width: 6px;
+        border-style: solid;
+        border-color: transparent;
+        border-left-color: #fff;
+      }
+
+      #yearScroller div:after {
+        content: "• • • • • ";
+        display: block;
+        font-size: 18px;
+        line-height: 1.3em;
+        width: 0.5em;
+        margin: 0.3em auto;
+        opacity: 0.3;
+        white-space: normal;
+      }
+
+      :host(.animate) vaadin-infinite-scroller {
+        transition: all 200ms;
       }
     </style>
 
-    <div id="toolbar">[[_yearAfterXMonths(_visibleMonthIndex)]]</div>
+    <div id="toolbar" desktop$="[[_desktopMode]]" on-tap="_toggleYearScroller">
+      [[_yearAfterXMonths(_visibleMonthIndex)]]
+      <iron-icon hidden$="[[_desktopMode]]" rotate$="[[_isYearScrollerVisible(_translateX)]]" icon="chevron-right"></iron-icon>
+    </div>
 
-    <vaadin-infinite-scroller id="scroller" on-scroll="_onListScroll" item-height="250" buffer-size="20">
-      <template>
-        <vaadin-month-calendar locale="[[locale]]" month="[[_dateAfterXMonths(index)]]" selected-date="{{selectedDate}}"></vaadin-month-calendar>
-      </template>
-    </vaadin-infinite-scroller>
+    <div id="scrollers" desktop$="[[_desktopMode]]">
+      <div id="fade"></div>
+      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-track="_track" item-height="250" buffer-size="6">
+        <template>
+          <vaadin-month-calendar locale="[[locale]]" month="[[_dateAfterXMonths(index)]]" selected-date="{{selectedDate}}"></vaadin-month-calendar>
+        </template>
+      </vaadin-infinite-scroller>
+      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" item-height="150" buffer-size="50">
+        <template>
+          <div>[[_yearAfterXYears(index)]]</div>
+        </template>
+      </vaadin-infinite-scroller>
+    </div>
 
   </template>
   <script>
@@ -64,8 +212,29 @@
           value: new Date()
         },
 
-        _visibleMonthIndex: Number
+        _visibleMonthIndex: Number,
 
+        _desktopMode: {
+          type: Boolean,
+          value: function() {
+            return window.innerWidth >= 375;
+          }
+        },
+
+        _translateX: {
+          observer: '_translateXChanged'
+        },
+
+        _yearScrollerWidth: {
+          value: 50
+        }
+
+      },
+
+      attached: function() {
+        this._translateX = this._yearScrollerWidth;
+        this.toggleClass('animate', true);
+        this.setScrollDirection('y', this.$.scroller);
       },
 
       /**
@@ -73,11 +242,109 @@
        */
       scrollToDate: function(date) {
         this.$.scroller.position = this._differenceInMonths(date, this._originDate);
-        this.async(this._onListScroll, 1);
+        this.async(this._onMonthScroll, 1);
       },
 
-      _onListScroll: function() {
+      _onMonthScroll: function() {
         this._visibleMonthIndex = Math.floor(this.$.scroller.position);
+        this.$.yearScroller.position = this.$.scroller.position / 12;
+      },
+
+      _onYearScroll: function() {
+        this.$.scroller.position = this.$.yearScroller.position * 12;
+        this._visibleMonthIndex = Math.floor(this.$.scroller.position);
+      },
+
+      _onYearTap: function(e) {
+        // http://gizma.com/easing/
+        var easingFunction = function(t, b, c, d) {
+          t /= d / 2;
+          if (t < 1) {
+            return c / 2 * t * t + b;
+          }
+          t--;
+          return -c / 2 * (t * (t - 2) - 1) + b;
+        };
+
+        var scrollDelta = e.detail.y - (this.$.yearScroller.getBoundingClientRect().top + this.$.yearScroller.clientHeight / 2);
+        var start = 0;
+        var duration = 300;
+        var initialScrollTop = this.$.yearScroller.$.scroller.scrollTop;
+        var smoothScroll = function(timestamp) {
+          start = start ||  timestamp;
+
+          var currentTime = timestamp - start;
+          var currentPos = easingFunction(currentTime, initialScrollTop, scrollDelta, duration);
+          this.$.yearScroller.$.scroller.scrollTop = currentPos;
+
+          if (currentTime < duration) {
+            window.requestAnimationFrame(smoothScroll);
+          }
+        }.bind(this);
+
+        // Start the animation.
+        window.requestAnimationFrame(smoothScroll);
+      },
+
+      _track: function(e) {
+        if (this._desktopMode) {
+          // No need to track for swipe gestures on desktop.
+          return;
+        }
+
+        switch (e.detail.state) {
+          case 'start':
+            this.toggleClass('animate', false);
+            break;
+          case 'track':
+            var newTranslateX = this._translateX + e.detail.dx / this._yearScrollerWidth * 5;
+            if (newTranslateX > this._yearScrollerWidth) {
+              this._closeYearScroller();
+            } else if (newTranslateX < 0) {
+              this._openYearScroller();
+            } else {
+              this._translateX = newTranslateX;
+            }
+            break;
+          case 'end':
+            this.toggleClass('animate', true);
+            if (this._translateX >= this._yearScrollerWidth / 2) {
+              this._closeYearScroller();
+            } else {
+              this._openYearScroller();
+            }
+            break;
+        }
+      },
+
+      _toggleYearScroller: function() {
+        this._isYearScrollerVisible() ? this._closeYearScroller() : this._openYearScroller();
+      },
+
+      _openYearScroller: function() {
+        this._translateX = 0;
+      },
+
+      _closeYearScroller: function() {
+        this._translateX = this._yearScrollerWidth;
+      },
+
+      _isYearScrollerVisible: function() {
+        return this._translateX < this._yearScrollerWidth;
+      },
+
+      _translateXChanged: function(x) {
+        if (!this._desktopMode) {
+          this.transform('translateX(' + (x - this._yearScrollerWidth) + 'px)', this.$.scroller);
+          this.transform('translateX(' + x + 'px)', this.$.yearScroller);
+          this.transform('translateX(' + -x + 'px)', this.$.fade);
+        }
+      },
+
+      _yearAfterXYears: function(index) {
+        var result = new Date(this._originDate);
+        result.setFullYear(parseInt(index) + this._originDate.getFullYear());
+        return result.getFullYear();
       },
 
       _yearAfterXMonths: function(months) {
@@ -93,8 +360,11 @@
       _differenceInMonths: function(date1, date2) {
         var months = (date1.getFullYear() - date2.getFullYear()) * 12;
         return months - date2.getMonth() + date1.getMonth();
-      }
+      },
 
+      _differenceInYears: function(date1, date2) {
+        return this._differenceInMonths(date1, date2) / 12;
+      }
     });
   </script>
 </dom-module>

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -32,6 +32,7 @@ This program is available under Apache License Version 2.0, available at https:/
       width: 100%;
       box-sizing: border-box;
       padding-right: 40px;
+      @apply(--vaadin-infinite-scroller-buffer);
     }
   </style>
 
@@ -131,18 +132,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
       if (upperThresholdReached || lowerThresholdReached) {
         this._translateBuffer(lowerThresholdReached);
-
-        // Call recursively to continue translating if necessary to make content visible.
-        this._scroll(null, true);
-      } else {
-        if (doUpdateClones) {
-          this._updateClones();
-        }
-        if (!this._preventScrollEvent) {
-          this.fire('scroll');
-        }
-        this._preventScrollEvent = false;
+        this._updateClones();
       }
+
+      if (!this._preventScrollEvent) {
+        this.fire('scroll');
+      }
+      this._preventScrollEvent = false;
     },
 
     /**
@@ -178,15 +174,9 @@ This program is available under Apache License Version 2.0, available at https:/
       this._buffers.forEach(function(buffer) {
         Polymer.Base.transform('translate3d(0, ' + buffer.translateY + 'px, 0)', buffer);
       });
+      this._buffers[0].updated = false;
       this._buffers[1].updated = false;
       this._updateClones();
-
-      this.debounce('updateBothBuffers', function() {
-        this._buffers.forEach(function(buffer) {
-          buffer.updated = false;
-        });
-        this._updateClones();
-      }, 500);
 
       this.listen(this.$.scroller, 'scroll', '_scroll');
     },

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -16,9 +16,15 @@
       }
 
       #title {
-        font-size: 120%;
         text-align: center;
-        padding: 0.4em 0;
+        padding: 0.4em 1em;
+        @apply(--paper-font-subhead);
+      }
+
+      #title span {
+        position: absolute;
+        left: 1em;
+        color: #999;
       }
 
       #monthGrid {
@@ -31,6 +37,7 @@
         width: 14.285714286%;
         box-sizing: border-box;
         padding: 0.4em 0;
+        @apply(--paper-font-body1);
       }
 
       #monthGrid div:not(:empty) {
@@ -39,28 +46,15 @@
 
       #monthGrid div.weekday {
         text-transform: uppercase;
-        font-size: 70%;
         color: #999;
         cursor: default;
+        padding: 0.7em 0;
+        @apply(--paper-font-caption);
       }
 
       #monthGrid div[today] {
         position: relative;
-      }
-
-      #monthGrid div[today]:before {
-        content: '';
-        display: block;
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        border: 2px solid #03a9f4;
-        border-radius: 50%;
-        box-sizing: border-box;
-        width: 1.6em;
-        height: 1.6em;
-        margin-left: -0.8em;
-        margin-top: -0.8em;
+        color: #03a9f4;
       }
 
       #monthGrid div[today][selected]:before {
@@ -130,8 +124,8 @@
         this._firstDayOfWeek = moment.localeData(locale)._week.dow;
       },
 
-      _getTitle: function(month) {
-        return this._monthNames[month.getMonth()];
+      _getTitle: function(month, monthNames) {
+        return monthNames[month.getMonth()] + ' ' + month.getFullYear();
       },
 
       _dateEquals: function(date1, date2) {


### PR DESCRIPTION
Fixes #35

This pull request introduces the parallax year scroller with several style and code changes.

 * Year scroller is a parallax scroller alongside the month scroller.
 * Year scroller is always visible if the viewport is wide enough.
 * If the year scroller is hidden, there are two ways toggle it open/closed.
  * Tap on the toolbar with the year number.
  * Swipe the month calendar to the left/right.
 * The "active" selection area of the scrollers is now the center of the scroller.
 * Tapping on the year scroller will do an animated scrolling to the tap position.
 * This PR also affects the styles widely, see the CSS changes. Notice especially following.
  * Fade to white effect on the month scroller when it has been slide to left.
  * Small indicator arrow on the year scroller.
  * Rotating arrow head icon on the toolbar to indicate open/closed state of the year scroller.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/49)
<!-- Reviewable:end -->
