### PR TITLE
Scrolling momentum on IOS Safari needs to be manually stopped…

### DIFF
--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -241,12 +241,12 @@
 
     <div id="scrollers" desktop$="[[_desktopMode]]">
       <div id="fade"></div>
-      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-track="_track" item-height="250" buffer-size="6">
+      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScroll" on-track="_track" item-height="250" buffer-size="6">
         <template>
           <vaadin-month-calendar locale="[[locale]]" month="[[_dateAfterXMonths(index)]]" selected-date="{{selectedDate}}"></vaadin-month-calendar>
         </template>
       </vaadin-infinite-scroller>
-      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" item-height="150" buffer-size="50">
+      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScroll" item-height="150" buffer-size="50">
         <template>
           <div>[[_yearAfterXYears(index)]]</div>
         </template>

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -23,6 +23,10 @@ This program is available under Apache License Version 2.0, available at https:/
       -ms-overflow-style: none;
     }
 
+    #scroller.notouchscroll {
+      -webkit-overflow-scrolling: auto;
+    }
+
     #scroller::-webkit-scrollbar {
       display: none;
     }
@@ -94,7 +98,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _preventScrollEvent: Boolean,
 
-      _bufferHeight: Number
+      _bufferHeight: Number,
+
+      _mayHaveMomentum: Boolean
     },
 
     ready: function() {
@@ -140,6 +146,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       if (!this._preventScrollEvent) {
         this.fire('scroll');
+        this._mayHaveMomentum = true;
       }
       this._preventScrollEvent = false;
     },
@@ -160,6 +167,18 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.scroller.scrollTop += index % 1 * this.itemHeight;
         this.listen(this.$.scroller, 'scroll', '_scroll');
       }
+
+      if (this._mayHaveMomentum) {
+        // Stop the possible iOS Safari momentum with -webkit-overflow-scrolling: auto;
+        this.$.scroller.classList.add('notouchscroll');
+        this._mayHaveMomentum = false;
+
+        this.async(function() {
+          // Restore -webkit-overflow-scrolling: touch; after a small delay.
+          this.$.scroller.classList.remove('notouchscroll');
+        }, 10);
+      }
+
     },
 
     /**


### PR DESCRIPTION
…when position is updated externally.

An iOS-specific UX issue: When you scroll one of the scrollers (years/months) fast (with momentum) and immediately switch to scrolling the other one, the scroller with remaining momentum still keeps updating position for the other one causing flickering and strange glitches.

This PR addresses the issue. Needs testing on iOS devices.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/71)
<!-- Reviewable:end -->
