### PR TITLE
Tweak vaadin-infinite-scroller update thresholds

### DIFF
--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -255,7 +255,7 @@
           <vaadin-month-calendar locale="[[locale]]" month="[[_dateAfterXMonths(index)]]" selected-date="{{selectedDate}}"></vaadin-month-calendar>
         </template>
       </vaadin-infinite-scroller>
-      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScroll" item-height="150" buffer-size="50">
+      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScroll" item-height="150" buffer-size="10">
         <template>
           <div>[[_yearAfterXYears(index)]]</div>
         </template>

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -136,8 +136,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       // Check if we scrolled enough to translate the buffer positions.
-      var upperThresholdReached = scrollTop > this._buffers[1].translateY + this._bufferHeight / 2;
-      var lowerThresholdReached = scrollTop < this._buffers[0].translateY + this._bufferHeight / 2;
+      var bufferOffset = this.$$('.buffer').offsetTop;
+      var upperThresholdReached = scrollTop > this._buffers[1].translateY + this.itemHeight + bufferOffset;
+      var lowerThresholdReached = scrollTop < this._buffers[0].translateY + this.itemHeight + bufferOffset;
 
       if (upperThresholdReached || lowerThresholdReached) {
         this._translateBuffer(lowerThresholdReached);


### PR DESCRIPTION
This small change will move the update threshold of the scroller to make sure we always have at least `buffer size - 1` items visible. Previously we had `buffer size / 2` as the minimum of visible items and it might sometimes lead to empty area being visible when the `vaadin-date-picker` was used inside a very high viewport.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/81)
<!-- Reviewable:end -->
