### PR TITLE
Prevent resetting initial position with a new date when reopening

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -94,6 +94,25 @@
         datepicker.open();
       });
 
+      it('should remember the original initial position on reopen', function(done) {
+        datepicker.initialPosition = null;
+
+        datepicker.open();
+
+        datepicker.async(function() {
+          var initialPosition = datepicker.$.overlay.initialPosition;
+
+          datepicker.close();
+          datepicker.open();
+
+          // wait needed to new Date() have a few milliseconds difference from previous open()
+          datepicker.async(function() {
+            expect(datepicker.$.overlay.initialPosition).to.eql(initialPosition);
+            done();
+          }, 1);
+        }, 1);
+      });
+
       it('should scroll to selected value by default', function(done) {
         var spy = sinon.spy(datepicker.$.overlay, 'scrollToDate');
         datepicker.value = '2000-02-01';

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -306,7 +306,9 @@ See paper-input-container documentation for styling the included input fields
       },
 
       _onOverlayOpened: function() {
-        this.$.overlay.initialPosition = this._selectedDate || this._parseDate(this.initialPosition) || new Date();
+        this.$.overlay.initialPosition = this._selectedDate ||
+                                         this.$.overlay.initialPosition ||
+                                         this._parseDate(this.initialPosition) || new Date();
 
         this.listen(window, 'scroll', '_onWindowScroll');
 
@@ -413,7 +415,7 @@ See paper-input-container documentation for styling the included input fields
 
       _onKeydown: function(e) {
         switch (this._eventKey(e)) {
-          case 'down':    
+          case 'down':
           case 'up':
             // prevent scrolling the page with arrows
             e.preventDefault();


### PR DESCRIPTION
Related with #76 

Assigning a new Date() value has a different timestamp everytime, so it will
always fire initialPositionChanged on reopen if we don't reuse it.

In English: the problem currently is that when you do keyboard navigation and close + reopen the overlay, it's scrolled back to Today if no initialPosition is set but the keyboard focus still stays where it was before closing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/85)
<!-- Reviewable:end -->