### PR TITLE
Focus the input container when the overlay is closed

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -136,19 +136,17 @@
         datepicker.open();
       });
 
-      describeSkipIf(safari, 'focus', function() {
-        // TODO: Sauce Labs bug doesn't allow Safari in OS X to focus.
-        it('should focus the input on overlay close', function(done) {
-          datepicker.addEventListener('iron-overlay-closed', function() {
-            var focusedElement = Polymer.dom(datepicker.root).querySelector('#inputcontainer:focus');
-            expect(focusedElement).not.to.eql(null);
-            done();
-          });
-          datepicker.addEventListener('iron-overlay-opened', function() {
-            datepicker.close();
-          });
-          datepicker.open();
+      it('should focus the input on overlay close', function(done) {
+        var spy = sinon.spy(datepicker.$.inputcontainer, 'focus');
+        datepicker.addEventListener('iron-overlay-closed', function() {
+          expect(spy.called).to.be.true;
+          done();
         });
+        datepicker.addEventListener('iron-overlay-opened', function() {
+          expect(spy.called).to.be.false;
+          datepicker.close();
+        });
+        datepicker.open();
       });
 
       it('should not have label defined by default', function() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -136,6 +136,21 @@
         datepicker.open();
       });
 
+      describeSkipIf(safari, 'focus', function() {
+        // TODO: Sauce Labs bug doesn't allow Safari in OS X to focus.
+        it('should focus the input on overlay close', function(done) {
+          datepicker.addEventListener('iron-overlay-closed', function() {
+            var focusedElement = Polymer.dom(datepicker.root).querySelector('#inputcontainer:focus');
+            expect(focusedElement).not.to.eql(null);
+            done();
+          });
+          datepicker.addEventListener('iron-overlay-opened', function() {
+            datepicker.close();
+          });
+          datepicker.open();
+        });
+      });
+
       it('should not have label defined by default', function() {
         expect(datepicker.label).to.be.undefined;
       });

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,5 @@
 var ios = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+var safari = navigator.userAgent.toLowerCase().indexOf('safari/') > -1 && navigator.userAgent.toLowerCase().indexOf('chrome/') == -1;
 
 function tap(element) {
   Polymer.Base.fire('tap', {}, {
@@ -28,4 +29,13 @@ function getFirstVisibleItem(scroller, bufferOffset) {
 
 function isFullscreen(datepicker) {
   return datepicker.$.overlay.getAttribute('fullscreen') !== null;
+}
+
+function describeSkipIf(bool, title, callback) {
+  bool = typeof bool == 'function' ? bool() : bool;
+  if (bool) {
+    describe.skip(title, callback);
+  } else {
+    describe(title, callback);
+  }
 }

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -377,6 +377,7 @@ See paper-input-container documentation for styling the included input fields
 
       _onOverlayClosed: function() {
         this.unlisten(window, 'scroll', '_onWindowScroll');
+        this.$.inputcontainer.focus();
 
         if (this._touchPrevented) {
           this._touchPrevented.forEach(function(prevented) {


### PR DESCRIPTION
Using tab key to navigate a form containing this element would be difficult without focusing the input container. The tab focus would be lost after selecting a date (or just closing with esc).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/88)
<!-- Reviewable:end -->
