### PR TITLE
Fix open/close toolbar arrow head behavior

### DIFF
--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -496,7 +496,7 @@
       },
 
       _isYearScrollerVisible: function() {
-        return this._translateX < this._yearScrollerWidth;
+        return this._translateX < this._yearScrollerWidth / 2;
       },
 
       _translateXChanged: function(x) {


### PR DESCRIPTION
Fixes #91 

This change will affect the toolbar arrow head so that it will rotate only after the year scroller half visible. Small (unintentional) swipe gestures horizontally will not trigger the animation anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/107)
<!-- Reviewable:end -->
