### PR TITLE
Moving the focus by months can no longer skip a month

### DIFF
--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -237,6 +237,21 @@
 
           });
 
+          it('should not skip a month', function() {
+            datepicker.value = '2000-01-31';
+            pageDown();
+
+            expect(focusedDate()).to.eql(new Date(2000, 1, 29));
+          });
+
+          it('should focus the previously focused date number if available', function() {
+            datepicker.value = '2000-01-31';
+            pageDown();
+            pageDown();
+
+            expect(focusedDate()).to.eql(new Date(2000, 2, 31));
+          });
+
           it('should focus next year with shift and pagedown', function() {
             pageDown('shift');
 

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -300,6 +300,8 @@
           observer: '_focusedDateChanged'
         },
 
+        _focusedMonthDate: Number,
+
         /**
          * Date which should be visible when there is no value selected.
          */
@@ -623,12 +625,19 @@
         var focus = this._currentlyFocusedDate();
 
         this.focusedDate = new Date(focus.getFullYear(), focus.getMonth(), focus.getDate() + days);
+        this._focusedMonthDate = this.focusedDate.getDate();
       },
 
       _moveFocusByMonths: function(months) {
         var focus = this._currentlyFocusedDate();
+        var dateToFocus = new Date(focus.getFullYear(), focus.getMonth() + months, 1);
+        var targetMonth = dateToFocus.getMonth();
 
-        this.focusedDate = new Date(focus.getFullYear(), focus.getMonth() + months, focus.getDate());
+        dateToFocus.setDate(this._focusedMonthDate || (this._focusedMonthDate = focus.getDate()));
+        if (dateToFocus.getMonth() !== targetMonth) {
+          dateToFocus.setDate(0);
+        }
+        this.focusedDate = dateToFocus;
       }
     });
   </script>


### PR DESCRIPTION
Fixes #94

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/109)
<!-- Reviewable:end -->
