### PR TITLE
Add support for custom validators

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,6 +41,7 @@
     "iron-component-page": "polymerelements/iron-component-page#~1.1.0",
     "iron-form": "PolymerElements/iron-form#^1.0.15",
     "iron-demo-helpers": "polymerelements/iron-demo-helpers#^1.1.1",
-    "iron-flex-layout": "polymerelements/iron-flex-layout#^1.3.0"
+    "iron-flex-layout": "polymerelements/iron-flex-layout#^1.3.0",
+    "iron-meta": "polymerelements/iron-meta#^1.1.1"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,6 +9,7 @@
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-flex-layout/iron-flex-layout-classes.html">
+  <link rel="import" href="../../iron-meta/iron-meta.html">
   <link rel="import" href="../vaadin-date-picker.html">
 
   <style is="custom-style" include="demo-pages-shared-styles iron-flex iron-flex-alignment">
@@ -126,6 +127,31 @@
         </style>
         <vaadin-date-picker class="custom-theme" label="Birthday"></vaadin-date-picker>
       </template>
+    </demo-snippet>
+
+    <h4>Custom Validator</h4>
+    <demo-snippet>
+      <template>
+        <vaadin-date-picker
+          auto-validate
+          validator="this-year-validator"
+          label="Only this year is accepted">
+        </vaadin-date-picker>
+
+        <script>
+          document.addEventListener('WebComponentsReady', function() {
+            new Polymer.IronMeta({
+              type: 'validator',
+              key: 'this-year-validator',
+              value: {
+                validate: function(value) {
+                  var currentYear = new Date().getFullYear();
+                  return new Date(value).getFullYear() === currentYear;
+                }
+              }
+            });
+          });
+        </script>
     </demo-snippet>
   </div>
 </body>

--- a/docs/vaadin-date-picker-features.adoc
+++ b/docs/vaadin-date-picker-features.adoc
@@ -103,3 +103,31 @@ You can still set and change the value of the [vaadinelement]#vaadin-date-picker
 ----
 <vaadin-date-picker readonly></vaadin-date-picker>
 ----
+
+== Custom Validators
+
+The [vaadinelement]#vaadin-date-picker# implements the [classname]#IronValidatableBehavior#, so it supports custom validators registered with an [elementname]#iron-meta# element.
+The validator to be used is defined using the [propertyname]#validator# property.
+Notice that it has to be registered with an [elementname]#iron-meta# element to be available.
+See the code example below for details.
+
+[source,html]
+----
+<vaadin-date-picker
+  validator="this-year-validator"
+  label="Only this year is accepted">
+</vaadin-date-picker>
+
+<script>
+  new Polymer.IronMeta({
+    type: 'validator',
+    key: 'this-year-validator',
+    value: {
+      validate: function(value) {
+        var currentYear = new Date().getFullYear();
+        return new Date(value).getFullYear() === currentYear;
+      }
+    }
+  });
+</script>
+----

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -9,10 +9,24 @@
   <script src="common.js"></script>
 
   <link rel="import" href="../../iron-form/iron-form.html">
+  <link rel="import" href="../../iron-meta/iron-meta.html">
   <link rel="import" href="../vaadin-date-picker.html">
 </head>
 
 <body>
+  <script>
+    document.addEventListener('WebComponentsReady', function() {
+      new Polymer.IronMeta({
+        type: 'validator',
+        key: 'year-2016-validator',
+        value: {
+          validate: function(value) {
+            return new Date(value).getFullYear() === 2016;
+          }
+        }
+      });
+    });
+  </script>
 
   <test-fixture id="datepicker">
     <template>
@@ -65,6 +79,21 @@
         expect(datepicker.invalid).to.be.equal(false);
       });
 
+      it('should validate correctly with custom validator', function() {
+        // Use a custom validator registered with <iron-meta>.
+        datepicker.validator = 'year-2016-validator';
+
+        // Try invalid value.
+        datepicker.value = '2014-01-01';
+        expect(datepicker.validate()).to.equal(false);
+        expect(datepicker.invalid).to.equal(true);
+
+        // Try valid value.
+        datepicker.value = '2016-01-01';
+        expect(datepicker.validate()).to.equal(true);
+        expect(datepicker.invalid).to.equal(false);
+      });
+
       it('should serialize correctly', function() {
         var form = fixture('datepicker-in-form', {name: 'foo'});
         datepicker = form.querySelector('vaadin-date-picker');
@@ -89,12 +118,13 @@
 
       it('should have disabled paper-input-container', function() {
         datepicker.disabled = true;
-        expect(datepicker.$$('paper-input-container').getAttribute('disabled')).to.equal('');
+        expect(datepicker.$.inputcontainer.getAttribute('disabled')).to.equal('');
+        expect(datepicker.$.input.disabled).to.equal(true);
       });
 
       it('should have readonly paper-input-container', function() {
         datepicker.readonly = true;
-        expect(datepicker.$$('paper-input-container').getAttribute('readonly')).to.equal('');
+        expect(datepicker.$.input.readOnly).to.equal(true);
       });
 
     });

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -161,9 +161,9 @@ See paper-input-container documentation for styling the included input fields
       }
     </style>
 
-    <paper-input-container id="inputcontainer" hideclear$="[[_hideClearIcon(_selectedDate, _opened, _fullscreen)]]" tabindex$="[[_getTabIndex(disabled, readonly)]]" on-touchend="_preventDefault" on-tap="open" on-keydown="_onKeydown" disabled$="[[disabled]]" readonly$="[[readonly]]" opened$="[[_opened]]">
+    <paper-input-container id="inputcontainer" hideclear$="[[_hideClearIcon(_selectedDate, _opened, _fullscreen)]]" tabindex$="[[_getTabIndex(disabled, readonly)]]" on-touchend="_preventDefault" on-tap="open" on-keydown="_onKeydown" disabled$="[[disabled]]" opened$="[[_opened]]" auto-validate$="[[autoValidate]]">
       <label id="label">[[label]]</label>
-      <input id="input" is="iron-input" autocomplete="off" bind-value="[[_formatDisplayed(_selectedDate, i18n.formatDate)]]" type="text" invalid="[[invalid]]" name$="[[name]]" required$="[[required]]" tabindex="-1" on-focus="_focusInputContainer">
+      <input id="input" is="iron-input" autocomplete="off" bind-value="[[_formatDisplayed(_selectedDate, i18n.formatDate)]]" type="text" invalid="[[invalid]]" name$="[[name]]" required$="[[required]]" tabindex="-1" on-focus="_focusInputContainer" validator="[[validator]]" readonly$="[[readonly]]" disabled$="[[disabled]]">
 
       <div suffix id="clear" on-tap="_clear" hidden$="[[_hideClearIcon(value, opened)]]">
         <iron-icon icon="clear"></iron-icon>
@@ -502,7 +502,7 @@ See paper-input-container documentation for styling the included input fields
        * @return {boolean}
        */
       _getValidity: function() {
-        return this.disabled || !this.required || this.$.input.validate();
+        return this.$.input.validate();
       },
 
       _focusInputContainer: function() {


### PR DESCRIPTION
This PR adds support for custom validators that are registered with `<iron-meta>` element. The implementation is based on how the support is done in `<paper-input>`.

Fixes #128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/129)
<!-- Reviewable:end -->