### PR TITLE
Make sure the scroller has visible content once scrolling stops

### DIFF
--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -150,6 +150,13 @@ This program is available under Apache License Version 2.0, available at https:/
         this._mayHaveMomentum = true;
       }
       this._preventScrollEvent = false;
+
+      this.debounce('scrollFinish', function() {
+        var scrollerRect = this.$.scroller.getBoundingClientRect();
+        if (!this._isVisible(this._buffers[0], scrollerRect) && !this._isVisible(this._buffers[1], scrollerRect)) {
+          this.position = this.position;
+        }
+      }, 200);
     },
 
     /**
@@ -239,9 +246,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }, this);
     },
 
-    _isVisible: function(itemWrapper, scrollerRect) {
-      var rect = itemWrapper.getBoundingClientRect();
-      return rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom;
+    _isVisible: function(element, container) {
+      var rect = element.getBoundingClientRect();
+      return rect.bottom > container.top && rect.top < container.bottom;
     },
 
     /**


### PR DESCRIPTION
If you scroll (the month scroller) fast enough on a slower mobile device, you'll probably notice the scroller content appearing empty at some point. This is because the buffers are out of the view due to really fast scrolling.

Normally the scroller recovers from this once the momentum slows down but if you'll for example stop the momentum with a finger, you might end up with an empty scroller.

This PR makes sure that the scroller has visible content every time scrolling stops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/132)
<!-- Reviewable:end -->