### PR TITLE
Window scroll needs to be listened at capture phase

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -19,6 +19,16 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="datepicker-wrapped">
+    <template>
+      <div style="height: 100px; overflow: scroll;">
+        <div style="height: 1000px">
+          <vaadin-date-picker></vaadin-date-picker>
+        </div>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     describe('Basic features', function() {
       var datepicker;
@@ -235,7 +245,7 @@
         });
 
         it('should realign on window scroll', function(done) {
-          var spy = sinon.spy(datepicker, '_onWindowScroll');
+          var spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
           Polymer.Base.fire('scroll', {}, {
             node: window
           });
@@ -245,13 +255,46 @@
           }, 100);
         });
 
+        it('should realign on container scroll', function(done) {
+          datepicker.close();
+
+          var container = fixture('datepicker-wrapped');
+          var datepickerWrapped = container.querySelector('vaadin-date-picker');
+
+          datepickerWrapped.addEventListener('iron-overlay-opened', function() {
+            var spy = sinon.spy(datepickerWrapped, '_updateAlignmentAndPosition');
+            container.scrollTop += 100;
+
+            datepickerWrapped.async(function() {
+              expect(spy.called).to.be.true;
+              done();
+            }, 100);
+          });
+          datepickerWrapped.open();
+        });
+
         it('should not realign on year/month scroll', function(done) {
-          var spy = sinon.spy(datepicker, '_onWindowScroll');
+          var spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
           datepicker.$.overlay.$.yearScroller.$.scroller.scrollTop += 100;
           datepicker.async(function() {
             expect(spy.called).to.be.false;
             done();
           }, 1);
+        });
+
+        it('should not realign once closed', function(done) {
+          datepicker.close();
+          datepicker.addEventListener('iron-overlay-closed', function() {
+            var spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
+            Polymer.Base.fire('scroll', {}, {
+              node: window
+            });
+            datepicker.async(function() {
+              expect(spy.called).to.be.false;
+              done();
+            }, 1);
+          });
+
         });
 
       });

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -376,17 +376,11 @@
       _onMonthScroll: function(e) {
         this._visibleMonthIndex = Math.floor(this.$.scroller.position);
         this.$.yearScroller.position = this.$.scroller.position / 12;
-        if (e) {
-          e.stopPropagation();
-        }
       },
 
       _onYearScroll: function(e) {
         this.$.scroller.position = this.$.yearScroller.position * 12;
         this._visibleMonthIndex = Math.floor(this.$.scroller.position);
-        if (e) {
-          e.stopPropagation();
-        }
       },
 
       _formatDisplayed: function(date, formatDate) {

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -323,6 +323,10 @@ See paper-input-container documentation for styling the included input fields
         }
       },
 
+      created: function() {
+        this._boundOnScroll = this._onScroll.bind(this);
+      },
+
       /**
        * Opens the dropdown.
        */
@@ -415,7 +419,7 @@ See paper-input-container documentation for styling the included input fields
           this.$.overlay.initialPosition || this._parseDate(this.initialPosition) || new Date();
         this.$.overlay.scrollToDate(this.$.overlay.focusedDate || this.$.overlay.initialPosition);
 
-        this.listen(window, 'scroll', '_onWindowScroll');
+        window.addEventListener('scroll', this._boundOnScroll, true);
 
         // Checking if the browser supports webkitOverflowScrolling
         if (document.createElement('div').style.webkitOverflowScrolling === '') {
@@ -447,7 +451,8 @@ See paper-input-container documentation for styling the included input fields
       },
 
       _onOverlayClosed: function() {
-        this.unlisten(window, 'scroll', '_onWindowScroll');
+        window.removeEventListener('scroll', this._boundOnScroll, true);
+
         this.$.inputcontainer.focus();
 
         if (this._touchPrevented) {
@@ -464,11 +469,13 @@ See paper-input-container documentation for styling the included input fields
         this._onOverlayClosed();
       },
 
-      _onWindowScroll: function() {
-        this.$.dropdown.style.bottom = 'auto';
-        this.$.dropdown.resetFit();
-        this._updateAlignmentAndPosition();
-        this.$.dropdown.fire('iron-resize');
+      _onScroll: function(e) {
+        if (e.target === window || !this.$.overlay.contains(e.target)) {
+          this.$.dropdown.style.bottom = 'auto';
+          this.$.dropdown.resetFit();
+          this._updateAlignmentAndPosition();
+          this.$.dropdown.fire('iron-resize');
+        }
       },
 
       _toggle: function(e) {


### PR DESCRIPTION
Connected to #134 

If you place the component inside a scrolling container, the dropdown should also reposition/realign when the container is scrolled (as opposed to only realigning on window scroll).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/137)
<!-- Reviewable:end -->