### PR TITLE
Added function to localize calendar title

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -72,6 +72,9 @@
             weekdaysShort: 'su_ma_ti_ke_to_pe_la'.split('_'),
             formatDate: function(d) {
               return [d.getDate(), d.getMonth() + 1, d.getFullYear()].join('.');
+            },
+            formatTitle: function(d, monthNames) {
+              return monthNames[d.getMonth()] + ' in ' + d.getFullYear();
             }
           };
         </script>

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -267,11 +267,17 @@ See paper-input-container documentation for styling the included input fields
         // Translation of the Cancel button text.
         cancel: 'Cancel',
 
-        // A function to format given `Date` object as
+        // A function to date format given `Date` object as
         // string.
         formatDate: function(d) {
           // returns a string representation of the given
           // Date object in 'MM/DD/YYYY' -format
+        },
+
+        // A function to calendar title format given `Date`
+        // object and 'monthNames' object as string.
+        formatTitle: function(d, monthNames) {
+          return monthNames[d.getMonth()] + ' ' + d.getFullYear();
         }
       }
 
@@ -292,6 +298,9 @@ See paper-input-container documentation for styling the included input fields
               cancel: 'Cancel',
               formatDate: function(d) {
                 return (d.getMonth() + 1) + '/' + d.getDate() + '/' + d.getFullYear();
+              },
+              formatTitle: function(d, monthNames) {
+                return monthNames[d.getMonth()] + ' ' + d.getFullYear();
               }
             };
           }

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -274,10 +274,11 @@ See paper-input-container documentation for styling the included input fields
           // Date object in 'MM/DD/YYYY' -format
         },
 
-        // A function to format given `Date` object and
-        // 'monthNames' object as calendar title string.
-        formatTitle: function(d, monthNames) {
-          return monthNames[d.getMonth()] + ' ' + d.getFullYear();
+        // A optional function to format given `month` and
+        // `fullYear` integers, `monthNames` object as
+        // calendar title string.
+        formatTitle: function(month, year) {
+          return monthNames[month] + ' ' + fullYear;
         }
       }
 
@@ -299,8 +300,8 @@ See paper-input-container documentation for styling the included input fields
               formatDate: function(d) {
                 return (d.getMonth() + 1) + '/' + d.getDate() + '/' + d.getFullYear();
               },
-              formatTitle: function(d, monthNames) {
-                return monthNames[d.getMonth()] + ' ' + d.getFullYear();
+              formatTitle: function(month, fullYear, monthNames) {
+                return monthNames[month] + ' ' + fullYear;
               }
             };
           }

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -267,15 +267,15 @@ See paper-input-container documentation for styling the included input fields
         // Translation of the Cancel button text.
         cancel: 'Cancel',
 
-        // A function to date format given `Date` object as
-        // string.
+        // A function to format given `Date` object as
+        // date string.
         formatDate: function(d) {
           // returns a string representation of the given
           // Date object in 'MM/DD/YYYY' -format
         },
 
-        // A function to calendar title format given `Date`
-        // object and 'monthNames' object as string.
+        // A function to format given `Date` object and
+        // 'monthNames' object as calendar title string.
         formatTitle: function(d, monthNames) {
           return monthNames[d.getMonth()] + ' ' + d.getFullYear();
         }

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -121,8 +121,8 @@
         }
       },
 
-      _getTitle: function(month, monthNames) {
-        return monthNames[month.getMonth()] + ' ' + month.getFullYear();
+      _getTitle: function(d, monthNames) {
+        return this.i18n.formatTitle(d, monthNames);
       },
 
       _dateEquals: function(date1, date2) {

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -121,8 +121,12 @@
         }
       },
 
-      _getTitle: function(d, monthNames) {
-        return this.i18n.formatTitle(d, monthNames);
+      _getTitle: function(month, monthNames) {
+        if (this.i18n && typeof this.i18n.formatTitle === 'function') {
+          return this.i18n.formatTitle(month.getMonth(), month.getFullYear(), monthNames);
+        }
+        // fallback
+        return monthNames[month.getMonth()] + ' ' + month.getFullYear();
       },
 
       _dateEquals: function(date1, date2) {


### PR DESCRIPTION
Added `formatTitle` function to option for localizing calendar title on `vaadin-month-calendar`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/152)
<!-- Reviewable:end -->