### PR TITLE
Improve handling of the invalid property

### DIFF
--- a/test/form-input.html
+++ b/test/form-input.html
@@ -92,6 +92,25 @@
         expect(datepicker.invalid).to.equal(false);
       });
 
+      it('should validate correctly with auto-validate', function() {
+        // Use a custom validator registered with <iron-meta>.
+        datepicker.validator = 'year-2016-validator';
+        datepicker.autoValidate = true;
+
+        // Set invalid value.
+        datepicker.value = '2014-01-01';
+        expect(datepicker.invalid).to.be.true;
+
+        // Change it to a valid value.
+        datepicker.value = '2016-01-01';
+        expect(datepicker.invalid).to.be.false;
+      });
+
+      it('should be possible to force invalid status', function() {
+        datepicker.invalid = true;
+        expect(datepicker.$.inputcontainer.invalid).to.be.true;
+      });
+
       it('should serialize correctly', function() {
         var form = fixture('datepicker-in-form', {name: 'foo'});
         datepicker = form.querySelector('vaadin-date-picker');

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -152,9 +152,9 @@ See paper-input-container documentation for styling the included input fields
       }
     </style>
 
-    <paper-input-container id="inputcontainer" hideclear$="[[_hideClearIcon(_selectedDate, _opened, _fullscreen)]]" tabindex$="[[_getTabIndex(disabled, readonly)]]" on-touchend="_preventDefault" on-tap="open" on-keydown="_onKeydown" disabled$="[[disabled]]" opened$="[[_opened]]" auto-validate$="[[autoValidate]]">
+    <paper-input-container id="inputcontainer" hideclear$="[[_hideClearIcon(_selectedDate, _opened, _fullscreen)]]" invalid="[[invalid]]" tabindex$="[[_getTabIndex(disabled, readonly)]]" on-touchend="_preventDefault" on-tap="open" on-keydown="_onKeydown" disabled$="[[disabled]]" opened$="[[_opened]]" auto-validate$="[[autoValidate]]">
       <label id="label">[[label]]</label>
-      <input id="input" is="iron-input" autocomplete="off" bind-value="[[_formatDisplayed(_selectedDate, i18n.formatDate)]]" type="text" invalid="[[invalid]]" name$="[[name]]" required$="[[required]]" tabindex="-1" on-focus="_focusInputContainer" validator="[[validator]]" readonly$="[[readonly]]" disabled$="[[disabled]]">
+      <input id="input" is="iron-input" autocomplete="off" bind-value="[[_formatDisplayed(_selectedDate, i18n.formatDate)]]" type="text" invalid="{{invalid}}" name$="[[name]]" required$="[[required]]" tabindex="-1" on-focus="_focusInputContainer" validator="[[validator]]" readonly$="[[readonly]]" disabled$="[[disabled]]">
 
       <div suffix id="clear" on-tap="_clear">
         <iron-icon icon="clear"></iron-icon>


### PR DESCRIPTION
Improves the handling of `invalid` property by matching it on how its done with `paper-input`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/157)
<!-- Reviewable:end -->