### PR TITLE
Align year numbers better with months

### DIFF
--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -117,6 +117,7 @@
         transform: translateX(100%);
         -webkit-tap-highlight-color: transparent;
         @apply(--paper-font-menu);
+        line-height: 8px;
         @apply(--vaadin-date-picker-yearscroller);
       }
 
@@ -255,7 +256,7 @@
       <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScrollTouchStart" item-height="80" buffer-size="25">
         <template>
           <div>[[_yearAfterXYears(index)]]</div>
-          <div style="font-size: 18px; line-height: 56px; opacity: 0.3;">•</div>
+          <div style="font-size: 18px; line-height: 72px; opacity: 0.3;">•</div>
         </template>
       </vaadin-infinite-scroller>
     </div>

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -117,7 +117,6 @@
         transform: translateX(100%);
         -webkit-tap-highlight-color: transparent;
         @apply(--paper-font-menu);
-        line-height: 8px;
         @apply(--vaadin-date-picker-yearscroller);
       }
 
@@ -137,7 +136,7 @@
         /* Center the year scroller position. */
         --vaadin-infinite-scroller-buffer: {
           top: 50%;
-          margin-top: -25px;
+          margin-top: -33px;
           width: 90px;
         }
       }
@@ -256,7 +255,7 @@
       <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScrollTouchStart" item-height="80" buffer-size="25">
         <template>
           <div>[[_yearAfterXYears(index)]]</div>
-          <div style="font-size: 18px; line-height: 72px; opacity: 0.3;">•</div>
+          <div style="font-size: 18px; line-height: 56px; opacity: 0.3;">•</div>
         </template>
       </vaadin-infinite-scroller>
     </div>


### PR DESCRIPTION
Align the year numbers with the arrow indicator together with the current month in the month scroller. E.g. for January, the arrow points roughly to the center of the year number text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/162)
<!-- Reviewable:end -->