### PR TITLE
Set validator property after the validate function is registered

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -144,8 +144,8 @@
     <demo-snippet>
       <template>
         <vaadin-date-picker
+          id="custom-validation"
           auto-validate
-          validator="this-year-validator"
           label="Only this year is accepted">
         </vaadin-date-picker>
 
@@ -161,6 +161,7 @@
                 }
               }
             });
+            document.querySelector('#custom-validation').validator = 'this-year-validator';
           });
         </script>
     </demo-snippet>


### PR DESCRIPTION
Fixes #179 

With the latest version of `iron-validatable-behavior` we need to set the `validator` property of our `vaadin-date-picker` __after__ the validator is first registered with `iron-meta`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/180)
<!-- Reviewable:end -->
