### PR TITLE
Fix iron-dropdown padding covering the clear button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "iron-dropdown": "polymerelements/iron-dropdown#^1.1.0",
+    "iron-dropdown": "polymerelements/iron-dropdown#^1.3.0",
     "iron-overlay-behavior": "polymerelements/iron-overlay-behavior#^1.3.2",
     "iron-icon": "polymerelements/iron-icon#^1.0.7",
     "iron-icons": "polymerelements/iron-icons#^1.1.2",

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -94,7 +94,7 @@
             var fullscreen = viewportWidth < 520;
 
             expect(isFullscreen(datepicker)).to.equal(fullscreen);
-            expect(dropdown.verticalOffset).to.equal(fullscreen ? 0 : datepicker.clientHeight - 10);
+            expect(dropdown.style.marginTop).to.equal((fullscreen ? 0 : datepicker.clientHeight + 2) + 'px');
             expect(dropdown.positionTarget).to.equal(fullscreen ? document.documentElement : datepicker);
             done();
           });

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -68,10 +68,6 @@ See paper-input-container documentation for styling the included input fields
         display: block;
       }
 
-      #dropdown:not([fullscreen]) {
-        padding: 12px 0 10px 0;
-      }
-
       #overlay {
         height: 100vh;
         width: 420px;
@@ -411,7 +407,6 @@ See paper-input-container documentation for styling the included input fields
 
       _updateAlignmentAndPosition: function() {
         var viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-        this.$.dropdown.verticalOffset = this._fullscreen ? 0 : this.clientHeight - 10;
         this.$.dropdown.positionTarget = this._fullscreen ? document.documentElement : this;
 
         var viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
@@ -420,6 +415,16 @@ See paper-input-container documentation for styling the included input fields
 
         this.$.dropdown.verticalAlign = bottomAlign ? 'bottom' : 'top';
         this.$.dropdown.horizontalAlign = this._fullscreen ? null : rightAlign ? 'right' : 'left';
+
+        // Previously used verticalOffset property has been recently deprecated
+        // in favor of using top and bottom margins.
+        if (this._fullscreen) {
+          this.$.dropdown.style.marginTop = 0;
+          this.$.dropdown.style.marginBottom = 0;
+        } else {
+          this.$.dropdown.style.marginTop = (bottomAlign ? 10 : this.clientHeight + 2) + 'px';
+          this.$.dropdown.style.marginBottom = (bottomAlign ? this.clientHeight : 10) + 'px';
+        }
 
         this.$.dropdown.refit();
       },


### PR DESCRIPTION
Fixes #176 

Fixed by applying `translateY` instead of `padding`. Using `margin` does not work as expected as it probably affects with some calculations of `iron-dropdown`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/183)
<!-- Reviewable:end -->
