### PR TITLE
Notify on open change

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -50,21 +50,21 @@
         expect(spy.calledOnce).to.be.true;
       });
 
-      it('should notify opened on open', function(done) {
-        datepicker.addEventListener('iron-overlay-opened', function() {
+      it('should notify opened changed on open', function(done) {
+        datepicker.addEventListener('opened-changed', function() {
           expect(datepicker.opened).to.be.true;
           done();
         });
         datepicker.open();
       });
 
-      it('should notify opened on open', function(done) {
+      it('should notify opened changed on close', function(done) {
         datepicker.addEventListener('iron-overlay-opened', function() {
+          datepicker.addEventListener('opened-changed', function() {
+            expect(datepicker.opened).to.be.false;
+            done();
+          });
           datepicker.close();
-        });
-        datepicker.addEventListener('iron-overlay-closed', function() {
-          expect(datepicker.opened).to.be.false;
-          done();
         });
         datepicker.open();
       });

--- a/test/basic.html
+++ b/test/basic.html
@@ -50,6 +50,25 @@
         expect(spy.calledOnce).to.be.true;
       });
 
+      it('should notify opened on open', function(done) {
+        datepicker.addEventListener('iron-overlay-opened', function() {
+          expect(datepicker.opened).to.be.true;
+          done();
+        });
+        datepicker.open();
+      });
+
+      it('should notify opened on open', function(done) {
+        datepicker.addEventListener('iron-overlay-opened', function() {
+          datepicker.close();
+        });
+        datepicker.addEventListener('iron-overlay-closed', function() {
+          expect(datepicker.opened).to.be.false;
+          done();
+        });
+        datepicker.open();
+      });
+
       it('should open with open call', function(done) {
         datepicker.addEventListener('iron-overlay-opened', function() {
           done();

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -61,7 +61,8 @@
        */
       opened: {
         type: Boolean,
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        notify: true
       },
 
       _fullscreen: {


### PR DESCRIPTION
Added `notify: true` to `opened` for convenience when working with the date picker. 

Fixes #220

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/221)
<!-- Reviewable:end -->
