### PR TITLE
Fixed suffix box-sizing to content box

### DIFF
--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -88,6 +88,7 @@ If you want to replace the default input field with a custom implementation, you
       }
 
       paper-input-container div[suffix] {
+        box-sizing: content-box;
         position: absolute;
         right: -4px;
         bottom: -4px;


### PR DESCRIPTION
...because their positioning relies on it

For example including Bootstrap in the same page with vaadin-date-picker would make the icons border-box and thus misplaced

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/231)
<!-- Reviewable:end -->
