### PR TITLE
Stop scroll events from bubbling outside the overlay

### DIFF
--- a/test/overlay.html
+++ b/test/overlay.html
@@ -27,6 +27,16 @@
         waitUntilScrolledTo(overlay, new Date(), done);
       });
 
+      it('should stop scroll events from bubbling outside the overlay', function() {
+        var scrollSpy = sinon.spy();
+        document.addEventListener('scroll', scrollSpy);
+        overlay.$.scroller.dispatchEvent(new CustomEvent('scroll', {
+          bubbles: true
+        }));
+        document.removeEventListener('scroll', scrollSpy);
+        expect(scrollSpy.called).not.to.be.true;
+      });
+
       it('should return correct month', function() {
         overlay._originDate = new Date(2016, 2, 31);
         expect(overlay._dateAfterXMonths(11).getMonth()).to.equal(1);

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -248,7 +248,7 @@
       <iron-icon rotate$="[[_isYearScrollerVisible(_translateX)]]" icon="chevron-right"></iron-icon>
     </div>
 
-    <div id="scrollers" desktop$="[[_desktopMode]]">
+    <div id="scrollers" desktop$="[[_desktopMode]]" on-scroll="_stopPropagation">
       <div id="fade"></div>
       <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" on-track="_track" item-height="250" buffer-size="6">
         <template>
@@ -778,6 +778,10 @@
            var closestDateDiff = Math.abs(closestDate.getTime() - date.getTime());
            return candidateDiff < closestDateDiff ? candidate : closestDate;
          });
+      },
+
+      _stopPropagation: function(e) {
+        e.stopPropagation();
       }
     });
   </script>


### PR DESCRIPTION
Iron-dropdown 1.5.0 introduced some additional scroll prevention logic causing the vaadin-date-picker's scrolling appear shaky (on iOS).

This PR makes the overlay stop scroll events from bubbling outside to avoid the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/241)
<!-- Reviewable:end -->
