### PR TITLE
Add week numbers to vaadin-month-calendar

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -66,6 +66,22 @@
       </template>
     </demo-snippet>
 
+    <h3>Date picker with week numbers</h3>
+    <demo-snippet>
+      <template>
+        <p>Week numbers are only supported for locales that start the week on Monday.</p>
+        <vaadin-date-picker id="weeks" show-week-numbers></vaadin-date-picker>
+        <script>
+          window.addEventListener('WebComponentsReady', function() {
+            // Async call needed here for IE11 compatibility.
+            Polymer.Base.async(function() {
+              var datepicker = document.querySelector('vaadin-date-picker#weeks');
+              datepicker.set('i18n.firstDayOfWeek', 1);
+            });
+          });
+        </script>
+      </template>
+    </demo-snippet>
   </div>
 </body>
 </html>

--- a/test/month-calendar.html
+++ b/test/month-calendar.html
@@ -212,6 +212,52 @@
         });
       });
 
+      describe('Week Numbers', function() {
+        beforeEach(function() {
+          monthCalendar.showWeekNumbers = true;
+          monthCalendar.set('i18n.firstDayOfWeek', 1);
+        });
+
+        function getWeekNumbers(cal) {
+          return Polymer.dom(cal.$.monthGrid).querySelectorAll('.weekSeparator').map(function(elem) {
+            return parseInt(elem.textContent, 10);
+          });
+        }
+
+        it('should render correct week numbers for Jan 2016', function(done) {
+          var month = new Date(2016, 0, 1);
+          monthCalendar.month = month;
+
+          monthCalendar.async(function() {
+            var weekNumbers = getWeekNumbers(monthCalendar);
+            expect(weekNumbers).to.eql([53, 1, 2, 3, 4]);
+            done();
+          });
+        });
+
+        it('should render correct week numbers for Dec 2015', function(done) {
+          var month = new Date(2015, 11, 1);
+          monthCalendar.month = month;
+
+          monthCalendar.async(function() {
+            var weekNumbers = getWeekNumbers(monthCalendar);
+            expect(weekNumbers).to.eql([49, 50, 51, 52, 53]);
+            done();
+          });
+        });
+
+        it('should render correct week numbers for Feb 2016', function(done) {
+          var month = new Date(2016, 1, 1);
+          monthCalendar.month = month;
+
+          monthCalendar.async(function() {
+            var weekNumbers = getWeekNumbers(monthCalendar);
+            expect(weekNumbers).to.eql([5, 6, 7, 8, 9]);
+            done();
+          });
+        });
+      });
+
     });
   </script>
 

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -66,6 +66,15 @@
         notify: true
       },
 
+      /**
+       * Set true to display ISO-8601 week numbers in the calendar. Notice that
+       * displaying week numbers is only supported when `i18n.firstDayOfWeek`
+       * is 1 (Monday).
+       */
+      showWeekNumbers: {
+        type: Boolean
+      },
+
       _fullscreen: {
         value: false,
         observer: '_fullscreenChanged'

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -251,7 +251,7 @@
 
     <div id="scrollers" desktop$="[[_desktopMode]]" on-scroll="_stopPropagation" on-track="_track">
       <div id="fade"></div>
-      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="265" buffer-size="6">
+      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="250" buffer-size="6">
         <template>
           <vaadin-month-calendar
             i18n="[[i18n]]"

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -251,14 +251,15 @@
 
     <div id="scrollers" desktop$="[[_desktopMode]]" on-scroll="_stopPropagation" on-track="_track">
       <div id="fade"></div>
-      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="250" buffer-size="6">
+      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="265" buffer-size="6">
         <template>
           <vaadin-month-calendar
             i18n="[[i18n]]"
             month="[[_dateAfterXMonths(index)]]"
             selected-date="{{selectedDate}}"
             focused-date="[[focusedDate]]"
-            ignore-taps=[[_ignoreTaps]]
+            ignore-taps="[[_ignoreTaps]]"
+            show-week-numbers="[[showWeekNumbers]]"
             min-date="[[minDate]]"
             max-date="[[maxDate]]">
           </vaadin-month-calendar>
@@ -336,6 +337,10 @@
 
         i18n: {
           type: Object
+        },
+
+        showWeekNumbers: {
+          type: Boolean
         },
 
         _ignoreTaps: Boolean,

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -43,6 +43,7 @@ Custom property | Description | Default
 `--vaadin-date-picker-calendar-cell-focused` | Mixin applied to a month calendar focused cell | `{}`
 `--vaadin-date-picker-calendar-cell-today-selected` | Mixin applied to a month calendar selected today cell | `{}`
 `--vaadin-date-picker-calendar-cell-disabled` | Mixin applied to a month calendar disabled cell | `{}`
+`--vaadin-date-picker-calendar-week-separator` | Mixin applied to a month calendar's week separator when week numbers are enabled | `{}`
 
 See paper-input-container documentation for styling the included input fields
 
@@ -213,6 +214,7 @@ If you want to replace the default input field with a custom implementation, you
           class="dropdown-content"
           on-close="close"
           focused-date="[[focusedDate]]"
+          show-week-numbers="[[showWeekNumbers]]"
           min-date="[[_minDate]]"
           max-date="[[_maxDate]]"
           tabindex="-1">

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -30,7 +30,8 @@
 
       #monthGrid div {
         text-align: center;
-        width: 14.285714286%;
+        width: calc(14.285714286% - 2px);
+        margin: 0 1px;
         box-sizing: border-box;
         padding: 6px 0;
         @apply(--paper-font-body1);

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -83,6 +83,21 @@
         cursor: default;
         @apply(--vaadin-date-picker-calendar-cell-disabled);
       }
+
+      #monthGrid .weekSeparator {
+        position: relative;
+        width: 100%;
+        height: 1px;
+        padding: 0;
+        font-size: 70%;
+        line-height: 0;
+        background: rgba(0, 0, 0, .08);
+        color: rgba(0, 0, 0, .4);
+        pointer-events: none;
+        margin-left: 1.5em;
+        text-indent: -1.5em;
+        @apply(--vaadin-date-picker-calendar-week-separator);
+      }
     </style>
 
     <div id="title">[[_getTitle(month, i18n.monthNames)]]</div>
@@ -90,7 +105,10 @@
       <template is="dom-repeat" items="[[_getWeekDayNames(i18n.weekdaysShort, i18n.firstDayOfWeek)]]">
         <div class="weekday">[[item]]</div>
       </template>
-      <template is="dom-repeat" items="[[_getDays(month, i18n.firstDayOfWeek, minDate, maxDate)]]">
+      <template is="dom-repeat" items="[[_days]]">
+        <template is="dom-if" if="[[_showWeekSeparator(showWeekNumbers, i18n.firstDayOfWeek, index)]]">
+          <span class="weekSeparator">[[_getWeekNumber(item, _days)]]</span>
+        </template>
         <div today$="[[_isToday(item)]]" selected$="[[_dateEquals(item, selectedDate)]]" focused$="[[_dateEquals(item, focusedDate)]]" date="[[item]]" disabled$="[[!_dateAllowed(item, minDate, maxDate)]]">[[_getDate(item)]]</div>
       </template>
     </div>
@@ -122,6 +140,10 @@
          */
         focusedDate: Date,
 
+        showWeekNumbers: {
+          type: Boolean
+        },
+
         i18n: {
           type: Object
         },
@@ -147,6 +169,11 @@
         maxDate: {
           type: Date,
           value: null
+        },
+
+        _days: {
+          type: Array,
+          computed: '_getDays(month, i18n.firstDayOfWeek, minDate, maxDate)'
         }
       },
 
@@ -183,25 +210,30 @@
         return date ? date.getDate() : '';
       },
 
+      _showWeekSeparator: function(showWeekNumbers, firstDayOfWeek, index) {
+        // Currently only supported for locales that start the week on Monday.
+        return showWeekNumbers && firstDayOfWeek === 1 && (index % 7 === 0);
+      },
+
       _isToday: function(date) {
         return this._dateEquals(new Date(), date);
       },
 
-      _getDays: function() {
+      _getDays: function(month, firstDayOfWeek, minDate, maxDate) {
         // First day of the month (at midnight).
         var date = new Date(0, 0);
-        date.setFullYear(this.month.getFullYear());
-        date.setMonth(this.month.getMonth());
+        date.setFullYear(month.getFullYear());
+        date.setMonth(month.getMonth());
         date.setDate(1);
 
         // Rewind to first day of the week.
-        while (date.getDay() !== this.i18n.firstDayOfWeek) {
+        while (date.getDay() !== firstDayOfWeek) {
           this._dateAdd(date, -1);
         }
 
         var days = [];
         var startMonth = date.getMonth();
-        var targetMonth = this.month.getMonth();
+        var targetMonth = month.getMonth();
         while (date.getMonth() === targetMonth || date.getMonth() === startMonth) {
           days.push(date.getMonth() === targetMonth ? new Date(date.getTime()) : null);
 
@@ -209,6 +241,36 @@
           this._dateAdd(date, 1);
         }
         return days;
+      },
+
+      _getWeekNumber: function(date, days) {
+        if (!date) {
+          // Get the first non-null date from the days array.
+          date = days.reduce(function(acc, d) { return (!acc && d ? d : acc); });
+        }
+
+        // Rest of the implementation from Vaadin Framework method
+        // com.vaadin.client.DateTimeService.getISOWeekNumber(date)
+        var dayOfWeek = date.getDay(); // 0 == sunday
+
+        // ISO 8601 use weeks that start on monday so we use
+        // mon=1,tue=2,...sun=7;
+        if (dayOfWeek === 0) {
+          dayOfWeek = 7;
+        }
+        // Find nearest thursday (defines the week in ISO 8601). The week number
+        // for the nearest thursday is the same as for the target date.
+        var nearestThursdayDiff = 4 - dayOfWeek; // 4 is thursday
+        var nearestThursday = new Date(date.getTime() + nearestThursdayDiff * 24 * 3600 * 1000);
+
+        var firstOfJanuary = new Date(nearestThursday.getFullYear(), 0, 1);
+        var timeDiff = nearestThursday.getTime() - firstOfJanuary.getTime();
+
+        // Rounding the result, as the division doesn't result in an integer
+        // when the given date is inside daylight saving time period.
+        var daysSinceFirstOfJanuary = Math.round(timeDiff / (24 * 3600 * 1000));
+
+        return Math.floor((daysSinceFirstOfJanuary) / 7 + 1);
       },
 
       _handleTap: function(e) {

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -37,6 +37,14 @@
         @apply(--vaadin-date-picker-calendar-cell);
       }
 
+      :host([week-numbers]) #monthGrid {
+        padding-left: 5%;
+      }
+
+      :host([week-numbers]) #monthGrid div {
+        padding: 3px 0;
+      }
+
       #monthGrid div:not(:empty) {
         cursor: pointer;
         color: var(--primary-text-color);
@@ -94,8 +102,8 @@
         background: rgba(0, 0, 0, .08);
         color: rgba(0, 0, 0, .4);
         pointer-events: none;
-        margin-left: 1.5em;
-        text-indent: -1.5em;
+        margin: 2px 0 2px 0;
+        text-indent: -5%;
         @apply(--vaadin-date-picker-calendar-week-separator);
       }
     </style>
@@ -177,6 +185,10 @@
         }
       },
 
+      observers: [
+        '_showWeekNumbersChanged(showWeekNumbers, i18n.firstDayOfWeek)'
+      ],
+
       _getTitle: function(month, monthNames) {
         return this.i18n.formatTitle(monthNames[month.getMonth()], month.getFullYear());
       },
@@ -208,6 +220,10 @@
 
       _getDate: function(date) {
         return date ? date.getDate() : '';
+      },
+
+      _showWeekNumbersChanged: function(showWeekNumbers, firstDayOfWeek) {
+        this.toggleAttribute('week-numbers', showWeekNumbers && firstDayOfWeek === 1);
       },
 
       _showWeekSeparator: function(showWeekNumbers, firstDayOfWeek, index) {


### PR DESCRIPTION
Fixes #198 

This is an MVP implementation for week numbers, which turned out to be a bit more complicated than originally imagined.

Currently this implementation requires the developer to set the `i18n.firstDayOfWeek` to `1` (=Monday) in order for the week numbers to appear. This approach is similar to one used by the `DateField` component of Vaadin Framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/243)
<!-- Reviewable:end -->
