### PR TITLE
Lazy load overlay content

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -385,7 +385,14 @@
           datepicker.set('i18n.clear', 'Tyhjennä');
           datepicker.set('i18n.today', 'Tänään');
           datepicker.set('i18n.cancel', 'Peruuta');
-          datepicker.async(done);
+
+          datepicker.$.overlay.$.scroller.addEventListener('animationend', function() {
+            datepicker.debounce('animations-finished', function() {
+              done();
+            }, 1);
+          });
+          datepicker.open();
+
         });
 
         it('should notify i18n mutation to children', function() {

--- a/test/overlay.html
+++ b/test/overlay.html
@@ -24,7 +24,14 @@
       beforeEach(function(done) {
         overlay = fixture('overlay');
         overlay.i18n = getDefaultI18n();
-        waitUntilScrolledTo(overlay, new Date(), done);
+
+        overlay.initialPosition = new Date();
+        overlay.$.scroller.addEventListener('animationend', function() {
+          overlay.debounce('animations-finished', function() {
+            waitUntilScrolledTo(overlay, new Date(), done);
+          }, 1);
+        });
+
       });
 
       it('should stop scroll events from bubbling outside the overlay', function() {

--- a/test/scroller.html
+++ b/test/scroller.html
@@ -16,16 +16,27 @@
   so in order to be able to test vaadin-infinite-scroller in isolation we're
   using the same instance in this suite -->
   <vaadin-infinite-scroller id="scroller" item-height="30" buffer-size="80">
-    <template>[[index]]</template>
+    <template><div>[[index]]</div></template>
   </vaadin-infinite-scroller>
 
   <script>
     describe('vaadin-infinite-scroller', function() {
       var scroller;
 
-      beforeEach(function(done) {
+      before(function(done) {
         scroller = document.querySelector('#scroller');
-        Polymer.Base.async(done, 1);
+
+        scroller.addEventListener('animationend', function() {
+          scroller.debounce('animations-finished', function() {
+            Polymer.Base.async(done, 1);
+          }, 1);
+        });
+
+        scroller.active = true;
+      });
+
+      afterEach(function (done) {
+        Polymer.Base.async(done, 1000);
       });
 
       function verifyPosition() {

--- a/test/scroller.html
+++ b/test/scroller.html
@@ -35,7 +35,7 @@
         scroller.active = true;
       });
 
-      afterEach(function (done) {
+      afterEach(function(done) {
         Polymer.Base.async(done, 1000);
       });
 
@@ -112,6 +112,28 @@
           done();
         });
         scroller.position = 10;
+      });
+
+      it('should not animate on second attach', function(done) {
+        var spy = sinon.spy();
+        scroller.addEventListener('animationstart', spy);
+        var parent = scroller.parentNode;
+        parent.removeChild(scroller);
+        parent.appendChild(scroller);
+        setTimeout(function() {
+          expect(spy.called).to.be.false;
+          done();
+        }, 100);
+
+      });
+
+      it('should have an instance stamped to every wrapper', function(done) {
+        scroller._buffers.forEach(function(buffer, bufferIndex) {
+          [].forEach.call(buffer.children, function(itemWrapper, index) {
+            expect(itemWrapper.firstElementChild).to.be.ok;
+          }.bind(this));
+        }, this);
+        done();
       });
 
     });

--- a/test/wai-aria.html
+++ b/test/wai-aria.html
@@ -132,6 +132,16 @@
         });
 
         describe('title announcer', function() {
+
+          beforeEach(function(done) {
+            overlay.$.scroller.addEventListener('animationend', function() {
+              overlay.debounce('animations-finished', function() {
+                done();
+              }, 1);
+            });
+            overlay.initialPosition = new Date();
+          });
+
           // Title announcer notifies the user when the overlay opens with
           // an explicit “<alert> Calender” announce.
 
@@ -178,11 +188,15 @@
           var yearScrollerContents;
 
           beforeEach(function(done) {
-            Polymer.Base.async(function() {
-              yearScrollerContents = Polymer.dom(overlay.$.yearScroller.root)
-                .querySelectorAll('.buffer > div > *');
-              done();
-            }, 1);
+            var scroller = overlay.$.yearScroller;
+            scroller.active = true;
+            scroller.addEventListener('animationend', function() {
+              scroller.debounce('animations-finished', function() {
+                yearScrollerContents = Polymer.dom(overlay.$.yearScroller.root)
+                  .querySelectorAll('.buffer > div > *');
+                done();
+              }, 100);
+            });
           });
 
           it('should contain button role for years', function() {

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -264,7 +264,7 @@
 
     <div id="scrollers" desktop$="[[_desktopMode]]" on-scroll="_stopPropagation" on-track="_track">
       <div id="fade"></div>
-      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="250" buffer-size="6">
+      <vaadin-infinite-scroller id="scroller" on-scroll="_onMonthScroll" on-touchstart="_onMonthScrollTouchStart" item-height="250" buffer-size="6" active="[[initialPosition]]">
         <template>
           <vaadin-month-calendar
             i18n="[[i18n]]"
@@ -278,7 +278,7 @@
           </vaadin-month-calendar>
         </template>
       </vaadin-infinite-scroller>
-      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScrollTouchStart" item-height="80" buffer-size="25">
+      <vaadin-infinite-scroller id="yearScroller" on-tap="_onYearTap" on-scroll="_onYearScroll" on-touchstart="_onYearScrollTouchStart" item-height="80" buffer-size="25" active="[[initialPosition]]">
         <template>
           <div role="button">[[_yearAfterXYears(index)]]</div>
           <div style="font-size: 18px; line-height: 56px; opacity: 0.3;" aria-hidden="true">•</div>

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -39,6 +39,15 @@ This program is available under Apache License Version 2.0, available at https:/
       padding-right: 40px;
       @apply(--vaadin-infinite-scroller-buffer);
     }
+
+    :host(:not([init-animation-done])) .buffer > * {
+      animation: fadein 0.2s;
+    }
+
+    @keyframes fadein {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
   </style>
 
   <template>
@@ -116,6 +125,34 @@ This program is available under Apache License Version 2.0, available at https:/
       if (active && !this._initialized) {
         this._createPool();
         this._initialized = true;
+      }
+    },
+
+    listeners: {
+      'animationstart': '_animationStart',
+      'animationend': '_animationEnd'
+    },
+
+    _animationEnd: function() {
+      this.toggleAttribute('init-animation-done', true);
+    },
+
+    _animationStart: function() {
+      if (!this._initDone) {
+        // Once the first set of items start fading in, stamp the rest
+        this.debounce('finish-init', function() {
+          this._buffers.forEach(function(buffer, bufferIndex) {
+            [].forEach.call(buffer.children, function(itemWrapper, index) {
+              this._ensureStampedInstance(itemWrapper);
+            }.bind(this));
+          }, this);
+
+          if (!this._buffers[0].translateY) {
+            this._reset();
+          }
+        }, 1);
+
+        this._initDone = true;
       }
     },
 
@@ -235,14 +272,22 @@ This program is available under Apache License Version 2.0, available at https:/
 
           Polymer.dom(buffer).appendChild(itemWrapper);
 
-          // TODO: Only scedule first set here, rest by animation end of the first set!
-          var stampDelay = this._isVisible(itemWrapper, container) ? 1 : 300;
-          this.async(this._stampInstance.bind(this, itemWrapper), stampDelay);
+          this.async(function(itemWrapper, container) {
+            // Only stamp the visible instances first
+            if (this._isVisible(itemWrapper, container)) {
+              this._ensureStampedInstance(itemWrapper);
+            }
+          }.bind(this, itemWrapper, container), 1); // Wait for first reset
+
         }
       }, this);
     },
 
-    _stampInstance: function(itemWrapper) {
+    _ensureStampedInstance: function(itemWrapper) {
+      if (itemWrapper.firstElementChild) {
+        return;
+      }
+
       var tmpInstance = itemWrapper.instance;
       itemWrapper.instance = this.stamp({});
       Polymer.dom(itemWrapper).appendChild(itemWrapper.instance.root);

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -101,7 +101,22 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _bufferHeight: Number,
 
-      _mayHaveMomentum: Boolean
+      _mayHaveMomentum: Boolean,
+
+      _initialized: Boolean,
+
+      active: Boolean
+    },
+
+    observers: [
+      '_activated(active)'
+    ],
+
+    _activated: function(active) {
+      if (active && !this._initialized) {
+        this._createPool();
+        this._initialized = true;
+      }
     },
 
     ready: function() {
@@ -112,12 +127,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
       var template = Polymer.dom(this).querySelector('template');
       this.templatize(template);
-      this._createPool();
-
-      this.async(function() {
-        this._reset();
-        this.flushDebouncer('updateAllClones');
-      }, 1);
     },
 
     _translateBuffer: function(up) {
@@ -217,16 +226,30 @@ This program is available under Apache License Version 2.0, available at https:/
     },
 
     _createPool: function() {
+      var container = this.getBoundingClientRect();
       this._buffers.forEach(function(buffer) {
         for (var i = 0; i < this.bufferSize; i++) {
           var itemWrapper = document.createElement('div');
           itemWrapper.style.height = this.itemHeight + 'px';
-          itemWrapper.instance = this.stamp({});
+          itemWrapper.instance = {};
 
           Polymer.dom(buffer).appendChild(itemWrapper);
-          Polymer.dom(itemWrapper).appendChild(itemWrapper.instance.root);
+
+          // TODO: Only scedule first set here, rest by animation end of the first set!
+          var stampDelay = this._isVisible(itemWrapper, container) ? 1 : 300;
+          this.async(this._stampInstance.bind(this, itemWrapper), stampDelay);
         }
       }, this);
+    },
+
+    _stampInstance: function(itemWrapper) {
+      var tmpInstance = itemWrapper.instance;
+      itemWrapper.instance = this.stamp({});
+      Polymer.dom(itemWrapper).appendChild(itemWrapper.instance.root);
+
+      Object.keys(tmpInstance).forEach(function(prop) {
+        itemWrapper.instance[prop] = tmpInstance[prop];
+      });
     },
 
     _updateClones: function(viewPortOnly) {


### PR DESCRIPTION
Fixes #106 

This PR makes `vaadin-date-picker` defer the rendering of it's overlay scroller content until it's actually opened.

Also the scrollers' initial rendering logic has been changed to minimize the delay when opened for the first time: The items at visible viewport are stamped first, rest of the items after the first set is done.

Impact on demo/index.html startup:
iPad2 Safari: 18.5s -> 4s
Desktop Chrome: 3s -> 1.2s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/268)
<!-- Reviewable:end -->
