### PR TITLE
Fix vaadin-infinite-scroller 'should default to position 0' test

### DIFF
--- a/test/scroller.html
+++ b/test/scroller.html
@@ -50,7 +50,7 @@
       }
 
       it('should default to position 0', function() {
-        expect(scroller.position).to.equal(0);
+        expect(parseInt(scroller.position, 10)).to.equal(0);
       });
 
       it('should have correct item height', function() {
@@ -68,7 +68,7 @@
             done();
           } else {
             scroller.$.scroller.scrollTop += scroller.itemHeight * 3.7;
-            scroller.async(scrollDown, 20);
+            scroller.async(scrollDown, 1);
           }
         }
 


### PR DESCRIPTION
In my environment (Linux/Chromium) this test was failing:

![](https://i.imgur.com/8uWEibV.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/294)
<!-- Reviewable:end -->
