### PR TITLE
Ux fixes v1.2

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,8 +68,8 @@ function testSauce(browsers, done) {
 
 gulp.task('test:desktop', function(done) {
   testSauce([
-    'Windows 10/chrome@48',
-    'Windows 10/firefox@44',
+    'Windows 10/chrome@50',
+    'Windows 10/firefox@47',
     'Windows 10/microsoftedge@13',
     'Windows 10/internet explorer@11',
     'OS X 10.11/safari@9.0'], done);
@@ -116,8 +116,8 @@ gulp.task('test:desktop:shadow', function(done) {
   args.dom = 'shadow';
 
   testSauce([
-    'Windows 10/chrome@48',
-    'Windows 10/firefox@44',
+    'Windows 10/chrome@50',
+    'Windows 10/firefox@47',
     'Windows 10/microsoftedge@13',
     //'Windows 10/internet explorer@11', // shadow polyfill seems to have issues in IE11.
     'OS X 10.11/safari@9.0'], done);

--- a/test/basic.html
+++ b/test/basic.html
@@ -259,14 +259,15 @@
         });
 
         it('should realign on window scroll', function(done) {
-          var spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
+          sinon.stub(datepicker, '_updateAlignmentAndPosition', function() {
+            if (!done._called) {
+              done._called = true;
+              done();
+            }
+          });
           Polymer.Base.fire('scroll', {}, {
             node: window
           });
-          datepicker.async(function() {
-            expect(spy.called).to.be.true;
-            done();
-          }, 100);
         });
 
         it('should realign on container scroll', function(done) {
@@ -275,16 +276,15 @@
           var container = fixture('datepicker-wrapped');
           var datepickerWrapped = container.querySelector('vaadin-date-picker');
 
-          datepickerWrapped.addEventListener('iron-overlay-opened', function() {
-            var spy = sinon.spy(datepickerWrapped, '_updateAlignmentAndPosition');
+          open(datepickerWrapped, function() {
+            sinon.stub(datepickerWrapped, '_updateAlignmentAndPosition', function() {
+              if (!done._called) {
+                done._called = true;
+                done();
+              }
+            });
             container.scrollTop += 100;
-
-            datepickerWrapped.async(function() {
-              expect(spy.called).to.be.true;
-              done();
-            }, 100);
           });
-          datepickerWrapped.open();
         });
 
         it('should not realign on year/month scroll', function(done) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -384,12 +384,13 @@
           datepicker.set('i18n.today', 'Tänään');
           datepicker.set('i18n.cancel', 'Peruuta');
 
-          datepicker.$.overlay.$.scroller.addEventListener('animationend', function() {
-            datepicker.debounce('animations-finished', function() {
-              done();
-            }, 1);
+          open(datepicker, function() {
+            Polymer.RenderStatus.afterNextRender(datepicker.$.overlay.$.scroller, function() {
+              Polymer.Base.async(function() {
+                done();
+              }, 1);
+            });
           });
-          datepicker.open();
 
         });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -50,54 +50,46 @@
         expect(spy.calledOnce).to.be.true;
       });
 
+      it('should open with open call', function(done) {
+        open(datepicker, function() {
+          done();
+        });
+      });
+
       it('should notify opened changed on open', function(done) {
-        datepicker.addEventListener('opened-changed', function() {
+        open(datepicker, function() {
           expect(datepicker.opened).to.be.true;
           done();
         });
-        datepicker.open();
       });
 
       it('should notify opened changed on close', function(done) {
-        datepicker.addEventListener('iron-overlay-opened', function() {
-          datepicker.addEventListener('opened-changed', function() {
+        open(datepicker, function() {
+          listenForEvent(datepicker, 'opened-changed', function() {
             expect(datepicker.opened).to.be.false;
             done();
           });
           datepicker.close();
         });
-        datepicker.open();
-      });
-
-      it('should open with open call', function(done) {
-        datepicker.addEventListener('iron-overlay-opened', function() {
-          done();
-        });
-        datepicker.open();
       });
 
       it('should close with close call', function(done) {
-        datepicker.addEventListener('iron-overlay-opened', function() {
-          datepicker.close();
+        open(datepicker, function() {
+          close(datepicker, function() {
+            expect(datepicker.opened).to.be.false;
+            done();
+          });
         });
-        datepicker.addEventListener('iron-overlay-closed', function() {
-          done();
-        });
-        datepicker.open();
       });
 
       it('should open on input tap', function(done) {
-        datepicker.addEventListener('iron-overlay-opened', function() {
-          done();
-        });
+        listenForEvent(datepicker, 'iron-overlay-opened', done);
         tap(datepicker.$.input);
       });
 
       it('should open on label tap', function(done) {
-        datepicker.addEventListener('iron-overlay-opened', function() {
-          done();
-        });
-        tap(datepicker.$.label);
+        listenForEvent(datepicker, 'iron-overlay-opened', done);
+        tap(datepicker.$.input);
       });
 
       it('should pass the placeholder attribute to the input tag', function() {
@@ -117,11 +109,10 @@
 
       it('should scroll to today by default', function(done) {
         var spy = sinon.spy(datepicker.$.overlay, 'scrollToDate');
-        datepicker.addEventListener('iron-overlay-opened', function() {
+        open(datepicker, function() {
           expect(monthsEqual(spy.firstCall.args[0], new Date())).to.be.true;
           done();
         });
-        datepicker.open();
       });
 
       it('should scroll to initial position', function(done) {
@@ -129,11 +120,10 @@
         var initialPositionDate = new Date(2016, 0, 1);
 
         var spy = sinon.spy(datepicker.$.overlay, 'scrollToDate');
-        datepicker.addEventListener('iron-overlay-opened', function() {
+        open(datepicker, function() {
           expect(spy.firstCall.args[0]).to.eql(initialPositionDate);
           done();
         });
-        datepicker.open();
       });
 
       it('should remember the original initial position on reopen', function(done) {
@@ -156,24 +146,21 @@
       it('should scroll to selected value by default', function(done) {
         var spy = sinon.spy(datepicker.$.overlay, 'scrollToDate');
         datepicker.value = '2000-02-01';
-        datepicker.addEventListener('iron-overlay-opened', function() {
+        open(datepicker, function() {
           expect(monthsEqual(spy.firstCall.args[0], new Date(2000, 1, 1))).to.be.true;
           done();
         });
-        datepicker.open();
       });
 
       it('should close on overlay date tap', function(done) {
-        datepicker.addEventListener('iron-overlay-closed', function() {
-          done();
-        });
-        datepicker.addEventListener('iron-overlay-opened', function() {
+        listenForEvent(datepicker, 'iron-overlay-closed', done);
+
+        open(datepicker, function() {
           Polymer.Base.fire('date-tap', {}, {
             bubbles: true,
             node: datepicker.$.overlay
           });
         });
-        datepicker.open();
       });
 
       it('should not have label defined by default', function() {
@@ -215,7 +202,12 @@
 
       it('should show clear icon', function(done) {
         datepicker.value = '2000-02-01';
-        datepicker.addEventListener('iron-overlay-opened', function() {
+        Polymer.Base.fire('date-tap', {}, {
+          bubbles: true,
+          node: datepicker.$.overlay
+        });
+
+        open(datepicker, function() {
           if (isFullscreen(datepicker)) {
             expect(datepicker.$.overlay.$.clear.clientHeight).not.to.equal(0);
           } else {
@@ -223,35 +215,31 @@
           }
           done();
         });
-        datepicker.open();
       });
 
       it('should open by tapping the calendar icon', function(done) {
+        listenForEvent(datepicker, 'iron-overlay-opened', done);
         tap(datepicker.$.calendar);
-        datepicker.addEventListener('iron-overlay-opened', function() {
-          done();
-        });
       });
 
       it('should scroll to a date on open', function(done) {
         // We must scroll to a date on every open because at least IE11 seems to reset
         // scrollTop while the dropdown is closed. This will result in all kind of problems.
         var spy = sinon.spy(datepicker.$.overlay, 'scrollToDate');
-        var openTimes = 0;
-        datepicker.addEventListener('iron-overlay-opened', function() {
+
+        open(datepicker, function() {
           expect(spy.called).to.be.true;
+
           spy.reset();
-          if (openTimes === 2) {
-            done();
-          } else if (openTimes < 2) {
-            datepicker.close();
-          }
-          openTimes++;
+          close(datepicker, function() {
+
+            open(datepicker, function() {
+              expect(spy.called).to.be.true;
+              done();
+            });
+          });
+          datepicker.close();
         });
-        datepicker.addEventListener('iron-overlay-closed', function() {
-          datepicker.open();
-        });
-        datepicker.open();
       });
 
       it('should not change datepicker width', function() {
@@ -267,12 +255,7 @@
       describe('window scroll realign', function() {
 
         beforeEach(function(done) {
-          datepicker.addEventListener('iron-overlay-opened', function() {
-            datepicker.async(done, 100);
-          });
-          datepicker.async(function() {
-            datepicker.open();
-          }, 100);
+          open(datepicker, done);
         });
 
         it('should realign on window scroll', function(done) {

--- a/test/common.js
+++ b/test/common.js
@@ -25,6 +25,24 @@ function getDefaultI18n() {
   };
 }
 
+function listenForEvent(elem, type, callback) {
+  var listener = function() {
+    elem.removeEventListener(type, listener);
+    callback();
+  };
+  elem.addEventListener(type, listener);
+}
+
+function open(datepicker, callback) {
+  listenForEvent(datepicker, 'iron-overlay-opened', callback);
+  datepicker.open();
+}
+
+function close(datepicker, callback) {
+  listenForEvent(datepicker, 'iron-overlay-closed', callback);
+  datepicker.close();
+}
+
 function tap(element) {
   Polymer.Base.fire('tap', {}, {
     bubbles: true,

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -535,30 +535,6 @@
             });
           });
 
-          it('should mark overlay focused on button blur', function() {
-            expect(datepicker.$.overlay._focused).not.to.be.ok;
-            MockInteractions.blur(datepicker.$.overlay.$.cancelButton);
-            expect(datepicker.$.overlay._focused).to.be.true;
-          });
-
-          it('should mark overlay unfocused on button focus', function() {
-            MockInteractions.focus(datepicker.$.overlay.$.cancelButton);
-            expect(datepicker.$.overlay._focused).to.be.false;
-          });
-
-          it('should cancel on cancel enter', function(done) {
-            datepicker.value = '2000-01-01';
-            datepicker.addEventListener('iron-overlay-closed', function() {
-              expect(datepicker.value).to.equal('2000-01-01');
-              done();
-            });
-            open(function() {
-              arrowDown();
-              datepicker.$.overlay.$.cancelButton.focus();
-              MockInteractions.pressEnter(datepicker.$.overlay.$.cancelButton);
-            });
-          });
-
         });
 
       });

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -338,131 +338,63 @@
 
         describe('esc behavior', function() {
 
+          it('should close the overlay on esc', function(done) {
+            datepicker.addEventListener('iron-overlay-closed', function() {
+              done();
+            });
+            open(function() {
+              esc();
+            });
+          });
+
           it('should revert input value on esc', function(done) {
+            datepicker.value = '2000-01-01';
             open(function() {
               inputText('1/2/2000');
               arrowDown();
               arrowDown();
               esc();
-              expect(target.value).to.equal('1/2/2000');
-              expect(focusedDate().getDate()).to.equal(2);
-              expect(datepicker.opened).to.be.true;
+              expect(target.value).to.equal('1/1/2000');
               done();
             });
           });
 
-          it('should empty on esc', function(done) {
-            var openedListener = function() {
-              datepicker.removeEventListener('iron-overlay-opened', openedListener);
-              esc();
-              datepicker.async(function() {
-                expect(target.value).to.equal('');
-                expect(datepicker.opened).to.be.true;
-                done();
-              }, 100);
-            };
-            datepicker.addEventListener('iron-overlay-opened', openedListener);
-            inputText('1/2/2000');
-          });
-
-          it('should revert selected value on second esc', function(done) {
-            datepicker.value = '2000-01-01';
-
-            var originalInputValue = target.value;
-            var openedListener = function() {
-              datepicker.removeEventListener('iron-overlay-opened', openedListener);
-              esc();
-              datepicker.async(function() {
-                esc();
-              }, 100);
-
-              datepicker.addEventListener('iron-overlay-closed', function() {
-                expect(target.value).to.equal(originalInputValue);
-                done();
-              });
-            };
-            datepicker.addEventListener('iron-overlay-opened', openedListener);
-            inputText('1/2/2000');
-
-          });
-
-          it('should restore focus to today on esc', function(done) {
-            var todayFormatted = datepicker.i18n.formatDate(new Date());
-
+          it('should revert input value on esc (empty)', function(done) {
+            datepicker.value = '';
             open(function() {
-              arrowDown();
-              esc();
-              datepicker.async(function() {
-                expect(target.value).to.equal(todayFormatted);
-                expect(datepicker.opened).to.be.true;
-                done();
-              }, 100);
-            });
-          });
-
-          it('should restore focus to selected date on esc', function(done) {
-            datepicker.value = '2000-01-01';
-
-            open(function() {
-              arrowDown();
-              esc();
-              datepicker.async(function() {
-                expect(target.value).to.equal('1/1/2000');
-                expect(datepicker.opened).to.be.true;
-                done();
-              }, 100);
-            });
-          });
-
-          it('should restore focus to selected date on esc after typing', function(done) {
-            datepicker.value = '2000-01-01';
-
-            open(function() {
-              target.bindValue = '';
               inputText('1/2/2000');
-              esc();
-              datepicker.async(function() {
-                expect(focusedDate().getDate()).to.eql(1);
-                done();
-              }, 100);
-            });
-          });
-
-          it('should restore focus to today date on esc after typing', function(done) {
-            open(function() {
-              target.bindValue = '';
-              inputText('1/2/2000');
-              esc();
-              datepicker.async(function() {
-                expect(focusedDate().getDate()).to.eql(new Date().getDate());
-                done();
-              }, 100);
-            });
-          });
-
-          it('should close after refocusing', function(done) {
-            open(function() {
+              arrowDown();
               arrowDown();
               esc();
-              arrowDown();
-              esc();
-              esc();
-              expect(target.value).to.be.empty;
-              esc();
-              expect(datepicker.opened).to.be.false;
+              expect(target.value).to.equal('');
               done();
             });
           });
 
-          it('should not select a value', function(done) {
+          it('should not change value on esc', function(done) {
+            datepicker.value = '2000-01-01';
+            datepicker.addEventListener('iron-overlay-closed', function() {
+              expect(datepicker.value).to.equal('2000-01-01');
+              done();
+            });
             open(function() {
-              datepicker.addEventListener('iron-overlay-closed', function() {
-                expect(datepicker.value).to.equal('');
-                done();
-              });
+              inputText('1/2/2000');
+              arrowDown();
               arrowDown();
               esc();
-              esc();
+            });
+          });
+
+          it('should not change value on esc (empty)', function(done) {
+            datepicker.value = '';
+            datepicker.addEventListener('iron-overlay-closed', function() {
+              expect(datepicker.value).to.equal('');
+              done();
+            });
+            open(function() {
+              inputText('1/2/2000');
+              arrowDown();
+              arrowDown();
               esc();
             });
           });

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -336,6 +336,35 @@
 
         });
 
+        describe('arrow keys', function() {
+
+          it('should forward up/down to overlay', function(done) {
+            open(function() {
+              arrowUp();
+              expect(datepicker._focusedDate.getDate()).not.to.eql(new Date().getDate());
+              done();
+            });
+          });
+
+          it('should not forward left/right to overlay when input has text', function(done) {
+            datepicker.value = '2000-01-01';
+            open(function() {
+              arrowLeft();
+              expect(datepicker._focusedDate.getDate()).to.eql(1);
+              done();
+            });
+          });
+
+          it('should forward left/right to overlay when input is empty', function(done) {
+            open(function() {
+              arrowLeft();
+              expect(datepicker._focusedDate.getDate()).not.to.eql(new Date().getDate());
+              done();
+            });
+          });
+
+        });
+
         describe('esc behavior', function() {
 
           it('should close the overlay on esc', function(done) {

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -218,7 +218,6 @@
           datepicker.addEventListener('iron-overlay-opened', function() {
             arrowDown();
             expect(datepicker._inputValue).to.equal('1/8/2000');
-            expect(getSelectionText()).to.equal('1/8/2000');
             done();
           });
           arrowDown();
@@ -290,19 +289,6 @@
           });
           open(function() {
             arrowDown();
-            datepicker.close();
-          });
-        });
-
-        it('should not clear selection on close (not focused)', function(done) {
-          datepicker.addEventListener('iron-overlay-closed', function() {
-            expect(target.selectionStart).not.to.equal(target.selectionEnd);
-            done();
-          });
-          open(function() {
-            arrowDown();
-            target.blur();
-            window.focus();
             datepicker.close();
           });
         });
@@ -498,6 +484,79 @@
             expect(result.getFullYear()).to.equal(2009);
             expect(result.getMonth()).to.equal(8);
             expect(result.getDate()).to.equal(9);
+          });
+
+        });
+
+        describe('focus modes', function() {
+
+          it('should be tabbable', function() {
+            expect(parseInt(datepicker.$.overlay.getAttribute('tabindex'), 10)).to.equal(0);
+          });
+
+          it('should focus the input on esc', function() {
+            arrowDown();
+            var spy = sinon.spy(datepicker.inputElement, 'focus');
+            esc();
+            expect(spy.called).to.be.true;
+          });
+
+          it('should focus the input on date tap', function() {
+            arrowDown();
+            var spy = sinon.spy(datepicker.inputElement, 'focus');
+            datepicker.$.overlay.fire('date-tap');
+            expect(spy.called).to.be.true;
+          });
+
+          it('should focus the input on date cancel', function() {
+            it('should focus the input on date tap', function() {
+              arrowDown();
+              var spy = sinon.spy(datepicker.inputElement, 'focus');
+              MockInteractions.tap(datepicker.$.overlay.$.cancelButton);
+              expect(spy.called).to.be.true;
+            });
+          });
+
+          it('should focus cancel on input shift tab', function(done) {
+            var spy = sinon.spy(datepicker.$.overlay.$.cancelButton, 'focus');
+            open(function() {
+              MockInteractions.pressAndReleaseKeyOn(datepicker.inputElement, 9, 'shift');
+              expect(spy.called).to.be.true;
+              done();
+            });
+          });
+
+          it('should focus input in cancel tab', function(done) {
+            var spy = sinon.spy(datepicker.inputElement, 'focus');
+            open(function() {
+              MockInteractions.pressAndReleaseKeyOn(datepicker.$.overlay.$.cancelButton, 9);
+              expect(spy.called).to.be.true;
+              done();
+            });
+          });
+
+          it('should mark overlay focused on button blur', function() {
+            expect(datepicker.$.overlay._focused).not.to.be.ok;
+            MockInteractions.blur(datepicker.$.overlay.$.cancelButton);
+            expect(datepicker.$.overlay._focused).to.be.true;
+          });
+
+          it('should mark overlay unfocused on button focus', function() {
+            MockInteractions.focus(datepicker.$.overlay.$.cancelButton);
+            expect(datepicker.$.overlay._focused).to.be.false;
+          });
+
+          it('should cancel on cancel enter', function(done) {
+            datepicker.value = '2000-01-01';
+            datepicker.addEventListener('iron-overlay-closed', function() {
+              expect(datepicker.value).to.equal('2000-01-01');
+              done();
+            });
+            open(function() {
+              arrowDown();
+              datepicker.$.overlay.$.cancelButton.focus();
+              MockInteractions.pressEnter(datepicker.$.overlay.$.cancelButton);
+            });
           });
 
         });

--- a/test/overlay.html
+++ b/test/overlay.html
@@ -27,10 +27,8 @@
         overlay.i18n = getDefaultI18n();
 
         overlay.initialPosition = new Date();
-        overlay.$.scroller.addEventListener('animationend', function() {
-          overlay.debounce('animations-finished', function() {
-            waitUntilScrolledTo(overlay, new Date(), done);
-          }, 1);
+        Polymer.RenderStatus.afterNextRender(overlay.$.scroller, function() {
+          waitUntilScrolledTo(overlay, new Date(), done);
         });
 
       });
@@ -83,6 +81,7 @@
         overlay.scrollToDate(date);
         waitUntilScrolledTo(overlay, date, function() {
           var offset = overlay.$.yearScroller.clientHeight / 2;
+          overlay.$.yearScroller.flushDebouncer('updateAllClones');
           expect(getFirstVisibleItem(overlay.$.yearScroller, offset).firstElementChild.textContent).to.equal('2000');
           done();
         });

--- a/test/scroller.html
+++ b/test/scroller.html
@@ -26,10 +26,8 @@
       before(function(done) {
         scroller = document.querySelector('#scroller');
 
-        scroller.addEventListener('animationend', function() {
-          scroller.debounce('animations-finished', function() {
-            Polymer.Base.async(done, 1);
-          }, 1);
+        Polymer.RenderStatus.afterNextRender(scroller, function() {
+          Polymer.Base.async(done, 1);
         });
 
         scroller.active = true;

--- a/test/scroller.html
+++ b/test/scroller.html
@@ -66,7 +66,7 @@
             done();
           } else {
             scroller.$.scroller.scrollTop += scroller.itemHeight * 3.7;
-            scroller.async(scrollDown, 1);
+            scroller.async(scrollDown, 20);
           }
         }
 

--- a/test/wai-aria.html
+++ b/test/wai-aria.html
@@ -127,8 +127,8 @@
         describe('title announcer', function() {
 
           beforeEach(function(done) {
-            overlay.$.scroller.addEventListener('animationend', function() {
-              overlay.debounce('animations-finished', function() {
+            Polymer.RenderStatus.afterNextRender(overlay.$.scroller, function() {
+              Polymer.Base.async(function() {
                 done();
               }, 1);
             });
@@ -183,12 +183,14 @@
           beforeEach(function(done) {
             var scroller = overlay.$.yearScroller;
             scroller.active = true;
-            scroller.addEventListener('animationend', function() {
-              scroller.debounce('animations-finished', function() {
+
+            Polymer.RenderStatus.afterNextRender(scroller, function() {
+              Polymer.Base.async(function() {
+                scroller.flushDebouncer('updateAllClones');
                 yearScrollerContents = Polymer.dom(overlay.$.yearScroller.root)
                   .querySelectorAll('.buffer > div > *');
                 done();
-              }, 100);
+              }, 1);
             });
           });
 

--- a/test/wai-aria.html
+++ b/test/wai-aria.html
@@ -113,13 +113,6 @@
           expect(datepickerLight.$.overlay.getAttribute('role')).to.equal('dialog');
         });
 
-        it('should not have tabindex attribute', function() {
-          // tabindex makes the overlay focusable, breaks iOS VoiceOver mode:
-          // the VoiceOver cursor always jumps to the (focused) overlay
-          // when a user taps inside to hear what is under the finger.
-          expect(parseInt(datepicker.$.overlay.getAttribute('tabindex'), 10)).to.be.NaN;
-          expect(parseInt(datepickerLight.$.overlay.getAttribute('tabindex'), 10)).to.be.NaN;
-        });
       });
 
       describe('overlay contents', function() {

--- a/test/wai-aria.html
+++ b/test/wai-aria.html
@@ -436,20 +436,22 @@
           datepicker.open();
         });
 
-        it('should debounce announcements', function(done) {
-          var announceSpy = sinon.spy();
-          document.body.addEventListener('iron-announce', announceSpy);
+        if (!ios) {
+          it('should announce once', function(done) {
+            var announceSpy = sinon.spy();
+            document.body.addEventListener('iron-announce', announceSpy);
 
-          datepicker._focusedDate = new Date(2016, 1, 1);
-          datepicker.open();
-          datepicker._focusedDate = new Date(2016, 1, 2);
+            datepicker._focusedDate = new Date(2016, 1, 1);
+            datepicker.open();
+            datepicker._focusedDate = new Date(2016, 1, 2);
 
-          Polymer.Base.async(function() {
-            expect(announceSpy.callCount).to.be.equal(1);
-            document.body.removeEventListener('iron-announce', announceSpy);
-            done();
-          }, 100);
-        });
+            Polymer.Base.async(function() {
+              expect(announceSpy.callCount).to.be.equal(1);
+              document.body.removeEventListener('iron-announce', announceSpy);
+              done();
+            }, 100);
+          });
+        }
 
         describe('i18n', function() {
           beforeEach(function() {

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -14,7 +14,7 @@
       '_selectedDateChanged(_selectedDate, i18n.formatDate)',
       '_validateInput(_selectedDate, _minDate, _maxDate)',
       '_focusedDateChanged(_focusedDate, i18n.formatDate)',
-      '_announceFocusedDate(_focusedDate, opened)'
+      '_announceFocusedDate(_focusedDate, opened, _ignoreAnnounce)'
     ],
 
     properties: {
@@ -280,6 +280,10 @@
       _ios: {
         type: Boolean,
         value: navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/)
+      },
+
+      _ignoreAnnounce: {
+        value: true
       }
     },
 
@@ -472,6 +476,8 @@
       this._focus();
 
       this.updateStyles();
+
+      this._ignoreAnnounce = false;
     },
 
     // A hack needed for iOS to prevent dropdown from being clipped in an
@@ -493,6 +499,8 @@
     },
 
     _onOverlayClosed: function() {
+      this._ignoreAnnounce = true;
+
       window.removeEventListener('scroll', this._boundOnScroll, true);
       window.removeEventListener('resize', this._boundOnScroll, true);
 
@@ -668,11 +676,9 @@
       }
     },
 
-    _announceFocusedDate: function(_focusedDate, opened) {
-      if (opened) {
-        this.debounce('_announceFocusedDate', function() {
-          this.$.overlay.announceFocusedDate();
-        }, 1);
+    _announceFocusedDate: function(_focusedDate, opened, _ignoreAnnounce) {
+      if (opened && !_ignoreAnnounce) {
+        this.$.overlay.announceFocusedDate();
       }
     }
   };

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -272,8 +272,6 @@
         value: null
       },
 
-      _forwardKeysToOverlay: Boolean,
-
       _noInput: {
         type: Boolean,
         computed: '_isNoInput(_fullscreen, i18n, i18n.*, _ios)'
@@ -292,7 +290,10 @@
     listeners: {
       'tap': 'open',
       'touchend': '_preventDefault',
-      'keydown': '_onKeydown'
+      'keydown': '_onKeydown',
+      'close': '_close',
+      'date-tap': '_close',
+      'focus-input': '_focusAndSelect'
     },
 
     ready: function() {
@@ -310,8 +311,15 @@
       this._updateAlignmentAndPosition();
       if (!this.disabled && !this.readonly) {
         this.$.dropdown.open();
-        this._forwardKeysToOverlay = false;
       }
+    },
+
+    _close: function(e) {
+      if (e) {
+        e.stopPropagation();
+      }
+      this.inputElement.focus();
+      this.close();
     },
 
     /**
@@ -362,7 +370,6 @@
     _focusedDateChanged: function(focusedDate, formatDate) {
       if (!this._ignoreFocusedDateChange && !this._noInput) {
         this._inputValue = focusedDate ? formatDate(focusedDate) : '';
-        this._input().setSelectionRange(0, this._inputValue.length);
       }
     },
 
@@ -497,7 +504,6 @@
       }
 
       this.updateStyles();
-      this._forwardKeysToOverlay = false;
 
       // Select the parsed input or focused date
       this._ignoreFocusedDateChange = true;
@@ -551,6 +557,13 @@
       }
     },
 
+    _focusAndSelect: function() {
+      if (!this._noInput) {
+        this._focus();
+        this.inputElement.setSelectionRange(0, this._inputValue.length);
+      }
+    },
+
     _preventDefault: function(e) {
       e.preventDefault();
     },
@@ -591,18 +604,20 @@
         case 'up':
           // prevent scrolling the page with arrows
           e.preventDefault();
-          if (!this._forwardKeysToOverlay) {
-            if (this.opened) {
-              this._forwardKeysToOverlay = true;
-            } else {
-              this.open();
-            }
+
+          if (this.opened) {
+            this.$.overlay.focus();
+            this.$.overlay._onKeydown(e);
+          } else {
+            this.open();
           }
+
           break;
         case 'left':
         case 'right':
-          if (this._inputValue === '' && !this._forwardKeysToOverlay && this.opened) {
-            this._forwardKeysToOverlay = true;
+          if (this._inputValue === '' && this.opened) {
+            this.$.overlay.focus();
+            this.$.overlay._onKeydown(e);
           }
           break;
         case 'enter':
@@ -613,16 +628,23 @@
           break;
         case 'esc':
           this._focusedDate = this._selectedDate;
-          this.close();
+          this._close();
           break;
         case 'tab':
-          this.close();
-          return;
+          if (this.opened) {
+            e.preventDefault();
+            // Clear the selection range (remains visible on IE)
+            this.inputElement.setSelectionRange(0, 0);
+            if (e.shiftKey) {
+              this.$.overlay.focusCancel();
+            } else {
+              this.$.overlay.focus();
+            }
+
+          }
+          break;
       }
 
-      if (this.opened && this._forwardKeysToOverlay) {
-        this.$.overlay._onKeydown(e);
-      }
     },
 
     _validateInput: function(date, min, max) {
@@ -637,8 +659,6 @@
         this._ignoreFocusedDateChange = true;
         this._focusedDate = parsedDate;
         this._ignoreFocusedDateChange = false;
-      } else {
-        this._forwardKeysToOverlay = false;
       }
 
       if (!this.opened) {

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -274,8 +274,6 @@
 
       _forwardKeysToOverlay: Boolean,
 
-      _cachedInputValue: String,
-
       _noInput: {
         type: Boolean,
         computed: '_isNoInput(_fullscreen, i18n, i18n.*, _ios)'
@@ -358,11 +356,11 @@
     _selectedDateChanged: function(selectedDate, formatDate) {
       this.value = this._formatISO(selectedDate);
       this._focusedDate = selectedDate;
-      this._cachedInputValue = this._inputValue = selectedDate ? formatDate(selectedDate) : '';
+      this._inputValue = selectedDate ? formatDate(selectedDate) : '';
     },
 
     _focusedDateChanged: function(focusedDate, formatDate) {
-      if (!this._ignoreFocusedDateChange && !this._noInput && this.opened) {
+      if (!this._ignoreFocusedDateChange && !this._noInput) {
         this._inputValue = focusedDate ? formatDate(focusedDate) : '';
         this._input().setSelectionRange(0, this._inputValue.length);
       }
@@ -595,7 +593,6 @@
           e.preventDefault();
           if (!this._forwardKeysToOverlay) {
             if (this.opened) {
-              this._cachedInputValue = this._inputValue;
               this._forwardKeysToOverlay = true;
             } else {
               this.open();
@@ -609,33 +606,12 @@
           this.close();
           break;
         case 'esc':
-          if (this._forwardKeysToOverlay) {
-            // The keys are forwarded to ovelay, revert the input text to the cached value
-            this._inputValue = this._cachedInputValue;
-            this._userInputValueChanged();
-
-            if (!this._inputValue) {
-              // Default to today
-              this.$.overlay.focusedDate = new Date();
-            }
-          } else {
-            var newInputValue = this._selectedDate ? this.i18n.formatDate(this._selectedDate) : '';
-            if (newInputValue !== this._inputValue) {
-              this.open();
-              this.$.overlay.focusedDate = this._selectedDate || new Date();
-            } else {
-              this._focusedDate = this._selectedDate;
-            }
-            this._inputValue = newInputValue;
-          }
-
-          this._forwardKeysToOverlay = false;
+          this._focusedDate = this._selectedDate;
+          this.close();
           break;
-
-          case 'tab':
-            this.close();
-            return;
-
+        case 'tab':
+          this.close();
+          return;
       }
 
       if (this.opened && this._forwardKeysToOverlay) {

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -559,7 +559,7 @@
      * Keyboard Navigation
      */
     _eventKey: function(e) {
-      var keys = ['down', 'up', 'enter', 'esc', 'tab'];
+      var keys = ['down', 'up', 'left', 'right', 'enter', 'esc', 'tab'];
 
       for (var i = 0; i < keys.length; i++) {
         var k = keys[i];
@@ -597,6 +597,12 @@
             } else {
               this.open();
             }
+          }
+          break;
+        case 'left':
+        case 'right':
+          if (this._inputValue === '' && !this._forwardKeysToOverlay && this.opened) {
+            this._forwardKeysToOverlay = true;
           }
           break;
         case 'enter':

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -65,10 +65,8 @@ need to define the name of value property using the `attrForValue` property.
         id="overlay" i18n="[[i18n]]"
         fullscreen$=[[_fullscreen]]
         label=[[label]]
-        on-date-tap="close"
         selected-date="{{_selectedDate}}"
         class="dropdown-content"
-        on-close="close"
         focused-date="{{_focusedDate}}"
         min-date="[[_minDate]]"
         max-date="[[_maxDate]]"

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -236,6 +236,12 @@
         @apply(--vaadin-date-picker-footer);
       }
 
+      paper-button.keyboard-focus {
+        color: var(--primary-background-color);
+        background: var(--primary-color);
+        outline: none;
+      }
+
       #announcer {
         display: inline-block;
         position: fixed;
@@ -274,7 +280,8 @@
             ignore-taps="[[_ignoreTaps]]"
             show-week-numbers="[[showWeekNumbers]]"
             min-date="[[minDate]]"
-            max-date="[[maxDate]]">
+            max-date="[[maxDate]]"
+            focused$="[[_focused]]">
           </vaadin-month-calendar>
         </template>
       </vaadin-infinite-scroller>
@@ -287,10 +294,10 @@
     </div>
 
     <div id="footer" on-touchend="_preventDefault" role="toolbar">
-      <paper-button id="todayButton" disabled="[[!_isTodayAllowed(minDate, maxDate)]]" on-tap="_onTodayTap" tabindex="-1">
+      <paper-button id="todayButton" disabled="[[!_isTodayAllowed(minDate, maxDate)]]" on-tap="_onTodayTap">
         [[i18n.today]]
       </paper-button>
-      <paper-button id="cancelButton" on-tap="_cancel" tabindex="-1">
+      <paper-button id="cancelButton" on-tap="_cancel">
         [[i18n.cancel]]
       </paper-button>
     </div>
@@ -304,7 +311,13 @@
       listeners: {
         'keydown': '_onKeydown',
         'scroll': '_stopPropagation',
-        'tap': '_stopPropagation'
+        'tap': '_stopPropagation',
+        'focus': '_onOverlayFocus',
+        'blur': '_onOverlayBlur'
+      },
+
+      hostAttributes: {
+        'tabIndex': '0'
       },
 
       properties: {
@@ -371,7 +384,9 @@
         /**
          * The latest date that can be selected. All later dates will be disabled.
          */
-        maxDate: Date
+        maxDate: Date,
+
+        _focused: Boolean
       },
 
       /**
@@ -409,6 +424,13 @@
       },
 
       /**
+       * Focuses the cancel button
+       */
+      focusCancel: function() {
+        this.$.cancelButton.focus();
+      },
+
+      /**
        * Scrolls the list to the given Date.
        */
       scrollToDate: function(date, animate) {
@@ -429,6 +451,19 @@
             this._scrollToPosition(diff - visibleItems + 1, true);
           }
         }
+      },
+
+      _onOverlayFocus: function() {
+        this._focused = true;
+        this.debounce('overlay-focus', function() {
+          if (this._focused) {
+            this._focusedDateChanged(this.focusedDate);
+          }
+        }, 1);
+      },
+
+      _onOverlayBlur: function() {
+        this._focused = false;
       },
 
       _initialPositionChanged: function(initialPosition) {
@@ -687,7 +722,7 @@
        * Keyboard Navigation
        */
       _eventKey: function(e) {
-        var keys = ['down', 'up', 'right', 'left', 'enter', 'space', 'home', 'end', 'pageup', 'pagedown'];
+        var keys = ['down', 'up', 'right', 'left', 'enter', 'space', 'home', 'end', 'pageup', 'pagedown', 'tab'];
 
         for (var i = 0; i < keys.length; i++) {
           var k = keys[i];
@@ -702,25 +737,45 @@
             dateToFocus;
 
         var eventKey = this._eventKey(e);
-        if (eventKey) {
+        if (eventKey === 'tab') {
+          e.stopPropagation();
+          if (this.hasAttribute('fullscreen')) {
+            e.preventDefault();
+          } else if ((this.$.cancelButton.focused && !e.shiftKey) || (this._focused && e.shiftKey)) {
+            // Return focus back to the input field
+            e.preventDefault();
+            this.fire('focus-input');
+            this._focused = false;
+          } else {
+            this._focused = !this._buttonFocused();
+          }
+        } else if (eventKey) {
           e.preventDefault();
           e.stopPropagation();
 
           switch (eventKey) {
             case 'down':
               this._moveFocusByDays(7);
+              this.focus();
               break;
             case 'up':
               this._moveFocusByDays(-7);
+              this.focus();
               break;
             case 'right':
-              this._moveFocusByDays(1);
+              if (!this._buttonFocused()) {
+                this._moveFocusByDays(1);
+              }
               break;
             case 'left':
-              this._moveFocusByDays(-1);
+              if (!this._buttonFocused()) {
+                this._moveFocusByDays(-1);
+              }
               break;
             case 'enter':
-              this._close();
+              if (!this._buttonFocused()) {
+                this._close();
+              }
               break;
             case 'space':
               if (vaadin.elements.datepicker.DatePickerHelper._dateEquals(this.focusedDate, this.selectedDate)) {
@@ -743,6 +798,10 @@
               break;
           }
         }
+      },
+
+      _buttonFocused: function() {
+        return this.$.todayButton.focused || this.$.cancelButton.focused;
       },
 
       _currentlyFocusedDate: function() {

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -44,6 +44,8 @@ Custom property | Description | Default
 `--vaadin-date-picker-calendar-cell-today-selected` | Mixin applied to a month calendar selected today cell | `{}`
 `--vaadin-date-picker-calendar-cell-disabled` | Mixin applied to a month calendar disabled cell | `{}`
 `--vaadin-date-picker-calendar-weeknumber-cell` | Mixin applied to a month calendar weeknumber cell | `{}`
+`--vaadin-date-picker-calendar-focused-cell-focused` | Mixin applied to a focused month calendar focused cell | `{}`
+
 
 See paper-input-container documentation for styling the included input fields
 
@@ -218,10 +220,8 @@ If you want to replace the default input field with a custom implementation, you
           id="overlay" i18n="[[i18n]]"
           fullscreen$="[[_fullscreen]]"
           label="[[label]]"
-          on-date-tap="close"
           selected-date="{{_selectedDate}}"
           class="dropdown-content"
-          on-close="close"
           focused-date="{{_focusedDate}}"
           show-week-numbers="[[showWeekNumbers]]"
           min-date="[[_minDate]]"

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -19,6 +19,7 @@ This program is available under Apache License Version 2.0, available at https:/
         position: relative;
         height: 100%;
         overflow: auto;
+        outline: none;
         margin-right: -40px;
         -webkit-overflow-scrolling: touch;
         -ms-overflow-style: none;
@@ -164,6 +165,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
       var template = Polymer.dom(this).querySelector('template');
       this.templatize(template);
+
+      // Firefox interprets elements with overflow:auto as focusable
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1069739
+      var isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+      if (isFirefox) {
+        this.$.scroller.tabIndex = -1;
+      }
     },
 
     _translateBuffer: function(up) {

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -130,7 +130,6 @@ This program is available under Apache License Version 2.0, available at https:/
     },
 
     listeners: {
-      'animationstart': '_animationStart',
       'animationend': '_animationEnd'
     },
 
@@ -138,20 +137,18 @@ This program is available under Apache License Version 2.0, available at https:/
       this.toggleAttribute('init-animation-done', true);
     },
 
-    _animationStart: function() {
+    _finishInit: function() {
       if (!this._initDone) {
         // Once the first set of items start fading in, stamp the rest
-        this.debounce('finish-init', function() {
-          this._buffers.forEach(function(buffer, bufferIndex) {
-            [].forEach.call(buffer.children, function(itemWrapper, index) {
-              this._ensureStampedInstance(itemWrapper);
-            }.bind(this));
-          }, this);
+        this._buffers.forEach(function(buffer, bufferIndex) {
+          [].forEach.call(buffer.children, function(itemWrapper, index) {
+            this._ensureStampedInstance(itemWrapper);
+          }.bind(this));
+        }, this);
 
-          if (!this._buffers[0].translateY) {
-            this._reset();
-          }
-        }, 1);
+        if (!this._buffers[0].translateY) {
+          this._reset();
+        }
 
         this._initDone = true;
       }
@@ -286,6 +283,8 @@ This program is available under Apache License Version 2.0, available at https:/
               this._ensureStampedInstance(itemWrapper);
             }
           }.bind(this, itemWrapper, container), 1); // Wait for first reset
+
+          Polymer.RenderStatus.afterNextRender(itemWrapper, this._finishInit.bind(this));
 
         }
       }, this);

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -48,7 +48,12 @@
         color: var(--primary-text-color);
         @apply(--vaadin-date-picker-calendar-date-cell);
       }
-      
+
+      #monthGrid div:not(:empty):not([disabled]):active {
+        background: var(--light-primary-color);
+        border-radius: 2px;
+      }
+
       #monthGrid div.weekday {
         text-transform: uppercase;
         color: var(--secondary-text-color);

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -48,7 +48,7 @@
         color: var(--primary-text-color);
         @apply(--vaadin-date-picker-calendar-date-cell);
       }
-
+      
       #monthGrid div.weekday {
         text-transform: uppercase;
         color: var(--secondary-text-color);
@@ -71,7 +71,6 @@
       }
 
       #monthGrid div[today][selected] {
-        color: var(--dark-theme-text-color);
         @apply(--vaadin-date-picker-calendar-cell-today-selected);
       }
 
@@ -82,12 +81,18 @@
         @apply(--vaadin-date-picker-calendar-cell-focused);
       }
 
-      #monthGrid div[selected] {
-        color: var(--light-primary-color);
+      :host([focused]) #monthGrid div[focused] {
         background: var(--primary-color);
-        box-sizing: border-box;
-        border-radius: 2px;
+        color: var(--primary-background-color);
+        @apply(--vaadin-date-picker-calendar-focused-cell-focused);
+      }
+
+      #monthGrid div[selected] {
         @apply(--vaadin-date-picker-calendar-cell-selected);
+      }
+
+      #monthGrid div[today][selected] {
+        @apply(--vaadin-date-picker-calendar-cell-today-selected);
       }
 
       #monthGrid div[disabled] {


### PR DESCRIPTION
Fixes #291, Fixes #296, Fixes #256, Fixes #275

- Esc works as cancel
- Left/right arrows move focus to overlay from an empty input field
- Today/Cancel buttons can be tabbed to
- Date cell has :active style
- Clearer separation between input/overlay focus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/297)
<!-- Reviewable:end -->
