### PR TITLE
Add <vaadin-demo-snippet> to fix examples for IE11

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -26,7 +26,7 @@
     </nav>
 
     <h3>Localizing</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker label="Syntymäpäivä" id="finnish" value="1980-08-14">
         </vaadin-date-picker>
@@ -68,10 +68,10 @@
         });
         </script>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Two date pickers side-by-side</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <div class="layout horizontal around-justified">
           <vaadin-date-picker id="start" label="Start"></vaadin-date-picker>
@@ -90,10 +90,10 @@
           });
         </script>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Styling</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <style is="custom-style">
           .custom-theme {
@@ -119,10 +119,10 @@
         </style>
         <vaadin-date-picker class="custom-theme" label="Birthday"></vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Custom Validator</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker
           id="custom-validation"
@@ -146,10 +146,10 @@
           });
         </script>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Custom Inputs</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <style is="custom-style">
           .my-input1 input {
@@ -164,9 +164,9 @@
           <input is="iron-input" placeholder="Date" size="10"/>
         </vaadin-date-picker-light>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <style is="custom-style">
           .my-input2 input {
@@ -183,7 +183,7 @@
          </div>
         </vaadin-date-picker-light>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
   </div>
 </body>

--- a/demo/common.html
+++ b/demo/common.html
@@ -1,6 +1,6 @@
 <!-- Common imports for all examples -->
 <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
-<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+<link rel="import" href="./vaadin-demo-snippet.html">
 <link rel="import" href="../../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="../../paper-styles/default-theme.html">
 <script src="../../elements-demo-resources/ga.js"></script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,87 +21,82 @@
       </ul>
     </nav>
     <h3>Plain date picker</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker></vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Label attribute</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker label="Pick a date">
         </vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Placeholder attribute</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker placeholder="Pick a date">
         </vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Label and placeholder attributes together</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker label="Birthday" placeholder="Pick a date">
         </vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Pre-selected value</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker label="Birthday" value="1980-08-14">
         </vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Disabled and readonly</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker disabled label="Disabled input" value="1980-08-14"></vaadin-date-picker>
         <vaadin-date-picker readonly label="Readonly input" value="1980-08-14"></vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Initial position</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker label="Birthday" initial-position="1980-01-01">
         </vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Min and max dates</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <vaadin-date-picker label="June 2017" min="2017-06-01" max="2017-06-30" initial-position="2017-06-01">
         </vaadin-date-picker>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Date picker with week numbers</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <p>Week numbers are only supported for locales that start the week on Monday.</p>
         <vaadin-date-picker id="weeks" show-week-numbers></vaadin-date-picker>
         <script>
-          window.addEventListener('WebComponentsReady', function() {
-            // Async call needed here for IE11 compatibility.
-            Polymer.Base.async(function() {
-              var datepicker = document.querySelector('vaadin-date-picker#weeks');
-              datepicker.set('i18n.firstDayOfWeek', 1);
-            });
-          });
+          var datepicker = document.querySelector('vaadin-date-picker#weeks');
+          datepicker.set('i18n.firstDayOfWeek', 1);
         </script>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
 
     <h3>Keyboard input</h3>
-    <demo-snippet>
+    <vaadin-demo-snippet>
       <template>
         <!--
         Using a 3rd party library to parse dates from the input text.
@@ -119,24 +114,19 @@
         <vaadin-date-picker label="Birthday" id="keyboard-input">
         </vaadin-date-picker>
         <script>
-          window.addEventListener('WebComponentsReady', function() {
-            // Async call needed here for IE11 compatibility.
-            Polymer.Base.async(function() {
-              var datepicker = document.querySelector('vaadin-date-picker#keyboard-input');
-              datepicker.set('i18n.parseDate', function(dateString) {
-                // See if we get exactly 1 match from the month names
-                var matches = datepicker.i18n.monthNames.filter(function(monthName) {
-                  return monthName.toLowerCase().startsWith(dateString.trim().toLowerCase());
-                });
-                dateString = matches.length === 1 ? matches[0] : dateString;
-                // Parse the date (using a 3rd party library)
-                return Sugar.Date.create(dateString);
-              });
+          var datepicker = document.querySelector('vaadin-date-picker#keyboard-input');
+          datepicker.set('i18n.parseDate', function(dateString) {
+            // See if we get exactly 1 match from the month names
+            var matches = datepicker.i18n.monthNames.filter(function(monthName) {
+              return monthName.toLowerCase().startsWith(dateString.trim().toLowerCase());
             });
+            dateString = matches.length === 1 ? matches[0] : dateString;
+            // Parse the date (using a 3rd party library)
+            return Sugar.Date.create(dateString);
           });
         </script>
       </template>
-    </demo-snippet>
+    </vaadin-demo-snippet>
   </div>
 </body>
 </html>

--- a/demo/vaadin-demo-snippet.html
+++ b/demo/vaadin-demo-snippet.html
@@ -1,0 +1,201 @@
+<!--
+The following is copied and adapted for IE11 better support from https://github.com/PolymerElements/iron-demo-helpers/blob/master/demo-snippet.html
+
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-icons/iron-icons.html">
+<link rel="import" href="../../marked-element/marked-element.html">
+<link rel="import" href="../../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../paper-styles/color.html">
+<link rel="import" href="../../paper-styles/shadow.html">
+<link rel="import" href="../../prism-element/prism-highlighter.html">
+<link rel="import" href="../../prism-element/prism-theme-default.html">
+
+<!--
+`vaadin-demo-snippet` is a helper element that displays the source of a code snippet and
+its rendered demo. It can be used for both native elements and
+Polymer elements.
+
+    Example of a native element demo
+
+        <vaadin-demo-snippet>
+          <template>
+            <input type="date">
+          </template>
+        </vaadin-demo-snippet>
+
+    Example of a Polymer <paper-checkbox> demo
+
+        <vaadin-demo-snippet>
+          <template>
+            <paper-checkbox>Checkbox</paper-checkbox>
+            <paper-checkbox checked>Checkbox</paper-checkbox>
+          </template>
+        </vaadin-demo-snippet>
+
+### Styling
+
+The following custom properties and mixins are available for styling:
+
+Custom property | Description | Default
+----------------|-------------|----------
+`--vaadin-demo-snippet` | Mixin applied to the entire element | `{}`
+`--vaadin-demo-snippet-demo` | Mixin applied to just the demo section | `{}`
+`--vaadin-demo-snippet-code` | Mixin applied to just the code section | `{}`
+
+@element vaadin-demo-snippet
+@demo demo/index.html
+-->
+
+<dom-module id="vaadin-demo-snippet">
+  <template>
+    <style is="custom-style" include="prism-theme-default"></style>
+    <style>
+      :host {
+        display: block;
+        @apply(--shadow-elevation-2dp);
+        @apply(--vaadin-demo-snippet);
+      }
+
+      .demo {
+        border-bottom: 1px solid var(--google-grey-300);
+        background-color: white;
+        margin: 0;
+        padding: 20px;
+        @apply(--vaadin-demo-snippet-demo);
+      }
+
+      .code {
+        padding: 20px;
+        margin: 0;
+        background-color: var(--google-grey-100);
+        font-size: 13px;
+        overflow: auto;
+        @apply(--vaadin-demo-snippet-code);
+      }
+
+      .code > pre {
+        margin: 0;
+        padding: 0 0 10px 0;
+      }
+
+      .code-container {
+        position: relative;
+      }
+
+      paper-icon-button {
+        position: absolute;
+        top: 0;
+        right: 0px;
+      }
+
+    </style>
+
+    <prism-highlighter></prism-highlighter>
+
+    <div class="demo">
+      <content id="content"></content>
+    </div>
+
+    <div class="code-container">
+      <marked-element markdown=[[_markdown]] id="marked">
+        <div class="markdown-html code" id="code"></div>
+      </marked-element>
+      <paper-icon-button
+          id="copyButton"
+          icon="content-copy"
+          title="copy to clipboard"
+          on-tap="_copyToClipboard">
+      </paper-icon-button>
+    </div>
+  </template>
+
+  <script>
+    'use strict';
+    Polymer({
+      is: 'vaadin-demo-snippet',
+
+      properties: {
+        _markdown: {
+          type: String,
+          value: ''
+        }
+      },
+
+      attached: function() {
+        var template = Polymer.dom(this).queryDistributedElements('template')[0];
+
+        // If there's no template, render empty code.
+        if (!template) {
+          this._markdown = '```\n```';
+          return;
+        }
+
+        var snippet = this.$.marked.unindent(template.innerHTML);
+
+        // Boolean properties are displayed as checked="", so remove the ="" bit.
+        snippet = snippet.replace(/=""/g, '');
+
+        this._markdown = '```\n' + snippet + '\n' + '```';
+
+        // Stamp the template.
+        if (!template.is) {
+          var scripts = template.content.querySelectorAll('script');
+          for (var i = 0; i < scripts.length; i++) {
+            if (scripts[i].innerHTML) {
+              scripts[i].innerHTML = this._wrapScript(scripts[i]);
+            }
+          }
+          Polymer.dom(this).appendChild(document.importNode(template.content, true));
+        }
+      },
+
+      _wrapScript: function() {
+        return
+          'window.addEventListener("WebComponentsReady", function() {' +
+            // Async call needed here for IE11 compatibility.
+            'Polymer.Base.async(function() {' +
+              scripts[i].innerHTML +
+            '});' +
+          '});';
+      },
+
+      _copyToClipboard: function() {
+        // From https://github.com/google/material-design-lite/blob/master/docs/_assets/snippets.js
+        var snipRange = document.createRange();
+        snipRange.selectNodeContents(this.$.code);
+        var selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(snipRange);
+        var result = false;
+        try {
+          result = document.execCommand('copy');
+          this.$.copyButton.icon = 'done';
+        } catch (err) {
+          // Copy command is not available
+          Polymer.Base._error(err);
+          this.$.copyButton.icon = 'error';
+        }
+
+        // Return to the copy button after a second.
+        setTimeout(this._resetCopyButtonState.bind(this), 1000);
+
+        selection.removeAllRanges();
+        return result;
+      },
+
+      _resetCopyButtonState: function() {
+        this.$.copyButton.icon = 'content-copy';
+      }
+    });
+  </script>
+
+</dom-module>


### PR DESCRIPTION
Related to:  https://github.com/vaadin/vaadin-grid/issues/544

This solution is aimed to get rid of

```js
window.addEventListener('WebComponentsReady', function() {
  // Async call needed here for IE11 compatibility.
  Polymer.Base.async(function() {
    ...
  });
});
```

for each our example, which has JS scripts.

Diff between `demo-snippet.html` and `vaadin-demo-snippet.html`: https://www.diffnow.com/?report=fn2qb

It this solution is ok, I'll apply it to all our demos to make examples work in IE11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/310)
<!-- Reviewable:end -->
