### PR TITLE
Use wct from command line instead of Gulp tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,23 @@
 sudo: false
 language: node_js
-node_js:
-  - "5.3"
-cache:
-  directories:
-    - node_modules
-install: travis_retry npm install && npm install -g bower && bower install
+node_js: stable
 env:
-  - TEST_SUITE=mobile
-  - TEST_SUITE=desktop
-  - TEST_SUITE=mobile:shadow
-  - TEST_SUITE=desktop:shadow
+  # desktop
+  - SAUCE_BROWSERS='[
+      "Windows 10/chrome@54",
+      "Windows 10/firefox@50",
+      "Windows 10/microsoftedge@13",
+      "Windows 10/internet explorer@11",
+      "OS X 10.11/safari@9.0"
+    ]'
+  # mobile
+  - SAUCE_BROWSERS='[
+      "OS X 10.11/iphone@9.2",
+      "OS X 10.11/ipad@9.2",
+      "Linux/android@5.1"
+    ]'
 script:
   - gulp lint:js
   - gulp lint:html
-  - travis_retry gulp test:$TEST_SUITE
+  - travis_retry wct
+  - travis_retry wct test/shadow.html

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,4 @@
 'use strict';
-var args = require('yargs').argv;
-var chalk = require('chalk');
-var wct = require('web-component-tester').test;
 var gulp = require('gulp');
 var jscs = require('gulp-jscs');
 var jshint = require('gulp-jshint');
@@ -9,78 +6,6 @@ var htmlExtract = require('gulp-html-extract');
 var sourcemaps = require('gulp-sourcemaps');
 var ts = require('gulp-typescript');
 var typings = require('gulp-typings');
-
-function cleanDone(done) {
-  return function(error) {
-    if (error) {
-      // Pretty error for gulp.
-      error = new Error(chalk.red(error.message || error));
-      error.showStack = false;
-    }
-    done(error);
-  };
-}
-
-function localAddress() {
-  var ip, tun, ifaces = require('os').networkInterfaces();
-  Object.keys(ifaces).forEach(function(ifname) {
-    ifaces[ifname].forEach(function(iface) {
-      if ('IPv4' == iface.family && !iface.internal) {
-        if (!ip) {
-          ip = iface.address;
-        }
-        if (/tun/.test(ifname)) {
-          tun = iface.address;
-        }
-      }
-    });
-  });
-  return tun || ip;
-}
-
-function test(options, done) {
-  wct(options, cleanDone(done));
-}
-
-function testSauce(browsers, done) {
-  test(
-    {
-      expanded: true,
-      browserOptions: {
-        name: localAddress() + ' / ' + new Date(),
-        build: 'vaadin-date-picker'
-      },
-      plugins: {
-        sauce: {
-          username: args.sauceUsername,
-          accessKey: args.sauceAccessKey,
-          browsers: browsers
-        }
-      },
-      extraScripts: args.dom === 'shadow' ? ['test/enable-shadow-dom.js'] : [],
-      root: '.',
-      webserver: {
-        port: 2000,
-        hostname: localAddress()
-      }
-    }, done);
-}
-
-gulp.task('test:desktop', function(done) {
-  testSauce([
-    'Windows 10/chrome@50',
-    'Windows 10/firefox@47',
-    'Windows 10/microsoftedge@13',
-    'Windows 10/internet explorer@11',
-    'OS X 10.11/safari@9.0'], done);
-});
-
-gulp.task('test:mobile', function(done) {
-  testSauce([
-    'OS X 10.11/iphone@9.2',
-    'OS X 10.11/ipad@9.2',
-    'Linux/android@5.1'], done);
-});
 
 gulp.task('lint:js', function() {
   return gulp.src([
@@ -110,39 +35,6 @@ gulp.task('lint:html', function() {
       .pipe(jscs())
       .pipe(jscs.reporter())
       .pipe(jscs.reporter('fail'));
-});
-
-gulp.task('test:desktop:shadow', function(done) {
-  args.dom = 'shadow';
-
-  testSauce([
-    'Windows 10/chrome@50',
-    'Windows 10/firefox@47',
-    'Windows 10/microsoftedge@13',
-    //'Windows 10/internet explorer@11', // shadow polyfill seems to have issues in IE11.
-    'OS X 10.11/safari@9.0'], done);
-});
-
-gulp.task('test:mobile:shadow', function(done) {
-  args.dom = 'shadow';
-
-  testSauce([
-    'OS X 10.11/iphone@9.2',
-    'OS X 10.11/ipad@9.2',
-    'Linux/android@5.1'], done);
-});
-
-// This is equivalent to:
-//  $ node_modules/.bin/wct --dom=shadow --local=chrome
-gulp.task('test', ['lint:js', 'lint:html'], function(done) {
-  args.dom = 'shadow';
-  test({
-      plugins: {
-        local: {
-          browsers: ['chrome']
-        }
-      }
-    }, done);
 });
 
 gulp.task('typings', function() {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "vaadin-date-picker",
-  "version": "0.0.0",
+  "version": "1.2.0",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
+  "repository": "https://github.com/vaadin/vaadin-date-picker.git",
   "devDependencies": {
     "@angular/common": "^2.0.0-rc.6",
     "@angular/compiler": "^2.0.0-rc.6",
@@ -10,7 +11,7 @@
     "@angular/platform-browser": "^2.0.0-rc.6",
     "@angular/platform-browser-dynamic": "^2.0.0-rc.6",
     "@vaadin/angular2-polymer": "^1.0.0-beta4",
-    "chalk": "^1.1.1",
+    "bower": "latest",
     "es6-shim": "^0.35.0",
     "gulp": "latest",
     "gulp-html-extract": "0.0.3",
@@ -21,10 +22,12 @@
     "gulp-typings": "^1.3.4",
     "jshint": "^2.8.0",
     "reflect-metadata": "0.1.3",
-    "rxjs": "5.0.0-beta.11",
+    "rxjs": "5.0.0-beta.12",
     "systemjs": "0.19.27",
-    "web-component-tester": "4.0.3",
-    "yargs": "^3.27.0",
+    "web-component-tester": "^5.0.0",
     "zone.js": "^0.6.17"
+  },
+  "scripts": {
+    "postinstall": "node_modules/.bin/bower install"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <script>
-    var shadow = document.location.search.indexOf('dom=shadow') > -1;
+    var shadow = document.location.search.indexOf('dom=shadow') > -1 || location.href.split('/').pop() === 'shadow.html';
     WCT._config.environmentScripts.push(shadow ? 'webcomponentsjs/webcomponents.js' : 'webcomponentsjs/webcomponents-lite.js');
 
     WCT.loadSuites([
@@ -26,7 +26,7 @@
       'late-upgrade.html',
       'wai-aria.html',
       'angular2.html'
-    ]);
+    ].map(function(item) { return item + (shadow ? '?dom=shadow' : ''); }));
   </script>
 </body>
 

--- a/test/shadow.html
+++ b/test/shadow.html
@@ -1,0 +1,1 @@
+index.html

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  registerHooks: function(context) {
+    if (process.env.SAUCE_BROWSERS) {
+      context.options.plugins.sauce.browsers = JSON.parse(process.env.SAUCE_BROWSERS);
+    }
+  }
+};


### PR DESCRIPTION
With this solution we don't have that weird `wct` bug when it results with great success even if tests are failing, so I updated the `wct` dependency to latest.

Build is still slow (20-30 min), but at least is passes :)

And output became prettier than is was: 

![](https://i.imgur.com/dD7Xlfb.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/312)
<!-- Reviewable:end -->
