### PR TITLE
Run Saucelabs tests for internal PRs except if branch contains 'quick/'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 sudo: false
+dist: trusty
 language: node_js
 node_js: stable
-env:
-  # desktop
-  - SAUCE_BROWSERS='[
-      "Windows 10/chrome@54",
-      "Windows 10/firefox@50",
-      "Windows 10/microsoftedge@13",
-      "Windows 10/internet explorer@11",
-      "OS X 10.11/safari@9.0"
-    ]'
-  # mobile
-  - SAUCE_BROWSERS='[
-      "OS X 10.11/iphone@9.2",
-      "OS X 10.11/ipad@9.2",
-      "Linux/android@5.1"
-    ]'
+
+cache:
+  directories:
+    - bower_components
+    - node_modules
+
+addons:
+  firefox: latest
+  google-chrome: latest
+
 script:
   - gulp lint
-  - travis_retry wct
-  - travis_retry wct --dom=shadow
+  - travis_retry xvfb-run wct
+  - travis_retry xvfb-run wct --dom=shadow

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -1,12 +1,27 @@
-'use strict';
-
 var args = require('yargs').argv;
 
 module.exports = {
   extraScripts: args.dom === 'shadow' ? ['test/enable-shadow-dom.js'] : [],
   registerHooks: function(context) {
-    if (process.env.SAUCE_BROWSERS) {
-      context.options.plugins.sauce.browsers = JSON.parse(process.env.SAUCE_BROWSERS);
+    // run Saucelabs tests for
+    //  - internal PRs, except cases when branch contains 'quick/'
+    //  - daily builds, triggered by cron
+    if (
+      (process.env.TRAVIS_EVENT_TYPE === 'push' && process.env.TRAVIS_BRANCH.indexOf('quick/') === -1) ||
+      process.env.TRAVIS_EVENT_TYPE === 'cron'
+    ) {
+      context.options.plugins.sauce.browsers = [
+        // desktop
+        'Windows 10/chrome@54',
+        'Windows 10/firefox@50',
+        'Windows 10/microsoftedge@13',
+        'Windows 10/internet explorer@11',
+        'OS X 10.11/safari@9.0',
+        // mobile
+        'OS X 10.11/iphone@9.2',
+        'OS X 10.11/ipad@9.2',
+        'Linux/android@5.1'
+      ];
     }
   }
 };


### PR DESCRIPTION
Related to https://github.com/vaadin/vaadin-upload/pull/141

Run Saucelabs tests for:

  - internal PRs, except cases when branch contains 'quick/'
  - daily builds, triggered by cron

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/318)
<!-- Reviewable:end -->
