### PR TITLE
Make datepicker modal by setting body pointer-events: none

### DIFF
--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -50,6 +50,23 @@
         datepicker.async(done, 1);
       });
 
+      it('should set body `pointer-events: none` on open and restore initial value on close', function(done) {
+        document.body.style.pointerEvents = 'painted';
+
+        datepicker.addEventListener('iron-overlay-opened', function() {
+          expect(getComputedStyle(document.body).pointerEvents).to.be.equal('none');
+          expect(getComputedStyle(datepicker).pointerEvents).to.be.equal('auto');
+          datepicker._close();
+        });
+
+        datepicker.addEventListener('iron-overlay-closed', function() {
+          expect(getComputedStyle(document.body).pointerEvents).to.be.equal('painted');
+          done();
+        });
+
+        datepicker.open();
+      });
+
       it('should not close on calendar icon down', function(done) {
         datepicker.addEventListener('iron-overlay-opened', function() {
           MockInteractions.down(datepicker.$.calendar);

--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -286,7 +286,15 @@
         value: true
       },
 
-      _focusOverlayOnOpen: Boolean
+      _focusOverlayOnOpen: Boolean,
+
+      /**
+       * When datepicker is opened, we're setting body pointer-events to none
+       * to make the datepicker behave in "modal" way. This variable keeps the
+       * previous state of body pointer-events to restore it when datepicker is
+       * closed.
+       */
+      _documentPointerEvents: String
     },
 
     created: function() {
@@ -483,6 +491,11 @@
 
       this.updateStyles();
 
+      // Set body pointer-events to 'none' to disable mouse interactions with
+      // other document nodes (datepicker is "modal")
+      this._documentPointerEvents = document.body.style.pointerEvents;
+      document.body.style.pointerEvents = 'none';
+
       this._ignoreAnnounce = false;
     },
 
@@ -518,6 +531,9 @@
       }
 
       this.updateStyles();
+
+      // Restore the initial body pointer-events
+      document.body.style.pointerEvents = this._documentPointerEvents;
 
       // Select the parsed input or focused date
       this._ignoreFocusedDateChange = true;

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -45,6 +45,10 @@ need to define the name of value property using the `attrForValue` property.
         display: block;
       }
 
+      :host([opened]) {
+        pointer-events: auto;
+      }
+
       #overlay {
         height: 100vh;
         width: 420px;

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -76,6 +76,10 @@ If you want to replace the default input field with a custom implementation, you
         display: block;
       }
 
+      :host([opened]) {
+        pointer-events: auto;
+      }
+
       #overlay {
         height: 100vh;
         width: 420px;


### PR DESCRIPTION
Fixes #289 

---

If this approach is okay, I'll try to figure out how to test it. But I need a feedback from the team about the approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/335)
<!-- Reviewable:end -->
