### PR TITLE
Fix flacky taps scroll tests by listening to scroll event

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
 
 <body>
   <script>
-    WCT._config.environmentScripts.push('webcomponentsjs/webcomponents-lite.js');
+    WCT._config.environmentScripts.push('webcomponentsjs/webcomponents.js');
 
     WCT.loadSuites([
       'basic.html',

--- a/test/overlay.html
+++ b/test/overlay.html
@@ -90,37 +90,47 @@
       describe('taps', function() {
 
         beforeEach(function(done) {
-          overlay.$.scroller.$.scroller.scrollTop += 1;
           // Wait for ignoreTaps to settle after initial scroll event
-          overlay.async(done, 350);
+          listenForEvent(overlay.$.scroller.$.scroller, 'scroll', function() {
+            overlay.async(done, 350);
+          });
+
+          overlay.$.scroller.$.scroller.scrollTop += 1;
         });
 
         it('should set ignoreTaps to calendar on scroll', function(done) {
-          overlay.$.scroller.$.scroller.scrollTop += 1;
-          overlay.async(function() {
+          listenForEvent(overlay.$.scroller.$.scroller, 'scroll', function() {
             expect(overlay.$.scroller.$$('vaadin-month-calendar').ignoreTaps).to.be.true;
             done();
-          }, 100);
+          });
+
+          overlay.$.scroller.$.scroller.scrollTop += 1;
         });
 
         it('should not react to year tap after scroll', function(done) {
           var spy = sinon.spy(overlay, '_scrollToPosition');
-          overlay.$.scroller.$.scroller.scrollTop += 1;
-          overlay.async(function() {
+
+          listenForEvent(overlay.$.scroller.$.scroller, 'scroll', function() {
             tap(overlay.$.yearScroller);
             expect(spy.called).to.be.false;
             done();
-          }, 100);
+          });
+
+          overlay.$.scroller.$.scroller.scrollTop += 1;
         });
 
         it('should react to year tap after 300ms elapsed after scroll', function(done) {
           var spy = sinon.spy(overlay, '_scrollToPosition');
+
+          listenForEvent(overlay.$.scroller.$.scroller, 'scroll', function() {
+            overlay.async(function() {
+              tap(overlay.$.yearScroller);
+              expect(spy.called).to.be.true;
+              done();
+            }, 350);
+          });
+
           overlay.$.scroller.$.scroller.scrollTop += 1;
-          overlay.async(function() {
-            tap(overlay.$.yearScroller);
-            expect(spy.called).to.be.true;
-            done();
-          }, 350);
         });
 
         it('should not react if the tap takes more than 300ms', function(done) {


### PR DESCRIPTION
The scroll event could be delayed for some time after the scrolling
was triggered. This delay matters, for example, when using full Shadow
DOM polyfill, and could make the tests flacky.

This changes the tests to depend on the scroll event rather then
relying on quick enough scroll event dispatch after triggering.

Fixes #334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/338)
<!-- Reviewable:end -->
