### PR TITLE
Remove override of padding-bottom on paper-input-container.

### DIFF
--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -85,7 +85,6 @@ If you want to replace the default input field with a custom implementation, you
         width: 420px;
       }
 
-
       #inputcontainer,
       #inputcontainer input {
         cursor: pointer;

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -85,9 +85,6 @@ If you want to replace the default input field with a custom implementation, you
         width: 420px;
       }
 
-      #inputcontainer {
-        padding-bottom: 0;
-      }
 
       #inputcontainer,
       #inputcontainer input {


### PR DESCRIPTION
**Problem**

When using date-picker element alongside normal paper-input elements, the padding-bottom of the container paper-input-container differ, causing the inputs to no align.

**Before fix**
![vaadin-date-picker-padding-bug-problem](https://cloud.githubusercontent.com/assets/3218762/23093442/d72d2d0c-f5e3-11e6-8f96-6f26d303cee8.png)

**After fix**
![vaadin-date-picker-padding-bug-fixed](https://cloud.githubusercontent.com/assets/3218762/23093441/d72d23c0-f5e3-11e6-8ce1-4d6eccad223a.png)

**Fix**
This commit removes the padding-bottom: 0 override of
paper-input-container, so that the date-picker aligns with the
height of  normal paper-input elements.

The override was introduced in commit
d888423def0ccc7869c801f3ef2315c14ff7b485. This change should probably be reviewed by it's author @tehapo before merging, since I guess there is a reason why it was added. Perhaps the original reason could be resolved differently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/342)
<!-- Reviewable:end -->
