### PR TITLE
Use Polymer.Gestures.addListener() for gesture events

### DIFF
--- a/vaadin-date-picker-mixin.html
+++ b/vaadin-date-picker-mixin.html
@@ -329,8 +329,8 @@ This program is available under Apache License Version 2.0, available at https:/
     ready() {
       super.ready();
       this._boundOnScroll = this._onScroll.bind(this);
-      this.addEventListener('tap', this.open.bind(this));
-      this.addEventListener('touchend', this._preventDefault.bind(this));
+      Polymer.Gestures.addListener(this, 'tap', this.open);
+      Polymer.Gestures.addListener(this, 'touchend', this._preventDefault);
       this.addEventListener('keydown', this._onKeydown.bind(this));
       this.addEventListener('close', this._close.bind(this));
       this.addEventListener('date-tap', this._close.bind(this));

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -314,8 +314,8 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
           this.setAttribute('tabindex', 0);
+          Polymer.Gestures.addListener(this, 'tap', this._stopPropagation);
           this.addEventListener('keydown', this._onKeydown.bind(this));
-          this.addEventListener('tap', this._stopPropagation.bind(this));
           this.addEventListener('focus', this._onOverlayFocus.bind(this));
           this.addEventListener('blur', this._onOverlayBlur.bind(this));
         }


### PR DESCRIPTION
According to the documentation [1], event listeners for gesture events
should use Polymer.Gestures.addListener() instead of
addEventListener().

This fixes a bug for mobile devices, where the 'tap' event in
vaadin-date-picker-mixin is not fired when tapping on the input
element.

Tested with polymer-2.0.1, chrome-58 on android, as well as
"device-toolbar" on chrome-59 on linux.

  [1] https://www.polymer-project.org/2.0/docs/devguide/gesture-events

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/394)
<!-- Reviewable:end -->
