### PR TITLE
Expose text-field prefix

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -18,6 +18,12 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="datepicker-prefix">
+    <template>
+      <vaadin-date-picker><div slot="prefix">foo</div></vaadin-date-picker>
+    </template>
+  </test-fixture>
+
   <test-fixture id="datepicker-wrapped">
     <template>
       <div style="height: 100px; overflow: scroll;">
@@ -534,6 +540,18 @@
         });
       });
 
+      describe('Slots', () => {
+        let textfield;
+        beforeEach(() => {
+          const datepicker = fixture('datepicker-prefix');
+          textfield = datepicker._inputElement;
+        });
+
+        it('should expose the text-field prefix slot', () => {
+          const slot = textfield.querySelector('slot[name=prefix]');
+          expect(slot.assignedNodes()[0].textContent).to.eql('foo');
+        });
+      });
     });
   </script>
 

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -74,7 +74,7 @@ This program is available under Apache License Version 2.0, available at https:/
         aria-label$="[[label]]"
         part="text-field"
       >
-
+      <slot name="prefix" slot="prefix"></slot>
       <div part="clear-button" slot="suffix" on-tap="_clear" role="button" aria-label$="[[i18n.clear]]"></div>
       <div part="toggle-button" slot="suffix" on-tap="_toggle" role="button" aria-label$="[[i18n.calendar]]" aria-expanded$="[[_getAriaExpanded(opened)]]"></div>
     </vaadin-text-field>


### PR DESCRIPTION
As discussed with @jouni all our elements need a prefix so as it's easy to apply designs for apps like BAS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/399)
<!-- Reviewable:end -->
