### PR TITLE
Fix bug in chrome 63 preventing click on cells in 1.x version

### DIFF
--- a/vaadin-date-picker-behavior.html
+++ b/vaadin-date-picker-behavior.html
@@ -491,6 +491,11 @@
       this._documentPointerEvents = document.body.style.pointerEvents;
       document.body.style.pointerEvents = 'none';
 
+      // Click on date cells do not work on Chrome 63 otherwise
+      var _pointerEvents = this.style.pointerEvents;
+      this.style.pointerEvents = 'auto';
+      this.style.pointerEvents = _pointerEvents;
+
       this._ignoreAnnounce = false;
     },
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/432)
<!-- Reviewable:end -->
