### PR TITLE
The -light version should be inline-block by default also

### DIFF
--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -15,7 +15,7 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       :host {
-        display: block;
+        display: inline-block;
       }
 
       :host([opened]) {


### PR DESCRIPTION
Connects to https://github.com/vaadin/components-team-tasks/issues/280

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/435)
<!-- Reviewable:end -->
