### PR TITLE
Fix textfield focus test

### DIFF
--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -452,7 +452,7 @@
 
           it('should be tabbable', () => {
             expect(parseInt(datepicker.$.overlay.getAttribute('tabindex'), 10)).to.equal(0);
-            expect(datepicker._inputElement.focused).to.be.undefined;
+            expect(datepicker._inputElement.focused).to.equal(false);
           });
 
           it('should focus the input on esc', () => {


### PR DESCRIPTION
Fix textfield focus test as now the default value of `focused` is set to `false` in control-state-mixin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/440)
<!-- Reviewable:end -->
