### PR TITLE
Enabled show week numbers for vaadin-date-picker-light

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-date-picker",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -79,9 +79,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.10.tgz",
-      "integrity": "sha512-9UZxEoNdOw0f+wu1qBEjG6G7JwibXjdqpEU0zOJgaPNSvf82f5m/MLXKjmiAnbOBsCiko3YPdT+/CESEiUn9Qg==",
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.16.tgz",
+      "integrity": "sha512-957wyvA86h7pv69cIGUQ1s5RKWFFuU4EyRQCV33TvL0oeJxM9L4hIKW9iomOf+HSEeKysG4RkNnPlhUvOtbHPg==",
       "dev": true
     },
     "@types/chai": {
@@ -139,12 +139,12 @@
       "dev": true
     },
     "@types/del": {
-      "version": "2.2.33",
-      "resolved": "https://registry.npmjs.org/@types/del/-/del-2.2.33.tgz",
-      "integrity": "sha512-bXwiHz4Ljz7FXGybdEtCHrsgJE+zIvxmGWgBLMwReMJi6yMenQs1ls3Q/s9rieuja9S/clDKVoXDS7BhEU2lYQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/del/-/del-3.0.0.tgz",
+      "integrity": "sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "5.0.32"
+        "@types/glob": "5.0.33"
       }
     },
     "@types/doctrine": {
@@ -159,10 +159,19 @@
       "integrity": "sha1-fOpBqyQukQ6xD2WuGK66RZ1ms18=",
       "dev": true
     },
+    "@types/estraverse": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-0.0.6.tgz",
+      "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.37"
+      }
+    },
     "@types/estree": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.34.tgz",
-      "integrity": "sha1-qnr2mjqRkiFx7kEbPJ2Pa+tK8yE=",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.37.tgz",
+      "integrity": "sha512-1IT6vNpmU9w18P3v6mN9idv18z5KPVTi4t7+rU9VLnkxo0LCam8IXy/eSVzOaQ1Wpabra2cN3A8K/SliPK/Suw==",
       "dev": true
     },
     "@types/express": {
@@ -171,17 +180,17 @@
       "integrity": "sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.52",
+        "@types/express-serve-static-core": "4.0.53",
         "@types/serve-static": "1.7.32"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.52",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.52.tgz",
-      "integrity": "sha512-UpN389YLcQEIn1t4Kxc8TlCrg43r6o8IcF57LvmbCGNhWzz0dEg4AaUsN6IHrrSjPzPmmJ1FLYXGPP/expXOWg==",
+      "version": "4.0.53",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.53.tgz",
+      "integrity": "sha512-zaGeOpEYp5G2EhjaUFdVwysDrfEYc6Q6iPhd3Kl4ip30x0tvVv7SuJvY3yzCUSuFlzAG8N5KsyY6BJg93/cn+Q==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/fast-levenshtein": {
@@ -205,7 +214,7 @@
       "integrity": "sha512-vm5OGsKc61Sx/GTRMQ9d0H0PYCDebT78/bdIBPCoPEHdgp0etaH1RzMmkDygymUmyXTj3rdWQn0sRUpYKZzljA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/freeport": {
@@ -216,13 +225,13 @@
       "optional": true
     },
     "@types/glob": {
-      "version": "5.0.32",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.32.tgz",
-      "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
+      "version": "5.0.33",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
+      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/glob-stream": {
@@ -231,8 +240,8 @@
       "integrity": "sha512-UxdJkuoXh48URR4gJSAQAXSTeo98KTsEalJc+7wNmWrkK+8/z/V71tddUYzxtM/nlDJEKHW5Fbyh02KuHwlytg==",
       "dev": true,
       "requires": {
-        "@types/glob": "5.0.32",
-        "@types/node": "8.0.28"
+        "@types/glob": "5.0.33",
+        "@types/node": "8.0.45"
       }
     },
     "@types/gulp-if": {
@@ -241,7 +250,7 @@
       "integrity": "sha1-IaVkrxqryA3/LRlfpmzT+IZK7CE=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.45",
         "@types/vinyl": "2.0.1"
       }
     },
@@ -279,7 +288,7 @@
       "integrity": "sha1-fKv6qrbGTVHjQQ2V4X3ZBh5BNTI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/mime": {
@@ -300,13 +309,13 @@
       "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/node": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ==",
+      "version": "8.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.45.tgz",
+      "integrity": "sha512-4q3e+DdiRli/aMgYOwtKCOrM4Vys+OQCcHts76lJUfKRCjfjfTqB4FjXsZ8jkyBEgPrPN0Rq93uCKmgd7ePY2w==",
       "dev": true
     },
     "@types/opn": {
@@ -315,24 +324,16 @@
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/parse5": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-0.0.31.tgz",
-      "integrity": "sha1-6Cekk6RDsVbhtYKi5MO9wAQPLuc=",
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
+      "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.88"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-          "dev": true
-        }
+        "@types/node": "8.0.45"
       }
     },
     "@types/pem": {
@@ -348,13 +349,13 @@
       "dev": true
     },
     "@types/request": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.39.tgz",
-      "integrity": "sha1-FouWz0JTxdVNQD90b4Lueu1Hziw=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.0.3.tgz",
+      "integrity": "sha512-cIvnyFRARxwE4OHpCyYue7H+SxaKFPpeleRCHJicft8QhyTNbVYsMwjvEzEPqG06D2LGHZ+sN5lXc8+bTu6D8A==",
       "dev": true,
       "requires": {
         "@types/form-data": "2.2.0",
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/resolve": {
@@ -363,7 +364,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/rimraf": {
@@ -510,7 +511,7 @@
       "integrity": "sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.52",
+        "@types/express-serve-static-core": "4.0.53",
         "@types/mime": "0.0.29"
       }
     },
@@ -521,21 +522,21 @@
       "dev": true
     },
     "@types/spdy": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.2.tgz",
-      "integrity": "sha512-MfIOcqTpECcKEMEAtpRQJqAdczKk/R55VGRfi5PDUlbpndrPz5t+knh7E3X0MnBMEOpRFY1oubLy81RHa6HrPg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
+      "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/temp": {
-      "version": "0.8.29",
-      "resolved": "https://registry.npmjs.org/@types/temp/-/temp-0.8.29.tgz",
-      "integrity": "sha1-w83BE+PBOPkOXpcNUeQbC39iZ40=",
+      "version": "0.8.30",
+      "resolved": "https://registry.npmjs.org/@types/temp/-/temp-0.8.30.tgz",
+      "integrity": "sha512-F4HAYlDpRHXKlvYIQFPKjPViwOERHOMLTlE4DwhTg04eoTCHQmpfun8P4BAoT9n+ffuEpevCuVQs2PUIFG7xmg==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/through": {
@@ -544,7 +545,7 @@
       "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/ua-parser-js": {
@@ -574,7 +575,7 @@
       "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/vinyl-fs": {
@@ -584,7 +585,7 @@
       "dev": true,
       "requires": {
         "@types/glob-stream": "3.1.31",
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.45",
         "@types/vinyl": "2.0.1"
       }
     },
@@ -596,27 +597,27 @@
       "optional": true
     },
     "@types/winston": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.5.tgz",
-      "integrity": "sha512-qMkxq+pSJgqE9I5NKEDJvZgLe+jK9ItOOQL9Ee2miUTPZMBKVWSx55suLaiwrGyQ/VqHhuD9Jv31wko1eTaKqQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.6.tgz",
+      "integrity": "sha512-gZsUc53u4JHqt5nvfgTnjNP1SkzDmDtY7eZz/8WUFL43Pp8KMR+g8LiHjslwLLheIS/hfGH55QW4tJVjNwYh/Q==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.45"
       }
     },
     "@types/yeoman-generator": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-1.0.3.tgz",
-      "integrity": "sha512-twfjJOWO2Rf1JAq5qPPe0mc7eHe1lRuz3RVTuekYkZQFF0Y6br9rGpMI1osxnIxBGBzpl47lSE/OFBoo1EFzfw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yeoman-generator/-/yeoman-generator-1.0.4.tgz",
+      "integrity": "sha512-iMm6ZU90vgupfqIDMQSSKh7VfM3susAoXx8Zv79FGnpiExtUTq8HeAg0AlrwqeP00VpPO/x/ytNejmmyuNoT/A==",
       "dev": true,
       "requires": {
         "@types/inquirer": "0.0.32"
       }
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.10.tgz",
-      "integrity": "sha512-GqIFgFcfJHBTGM/iOJo1bnPBv58EYJTFQFYH+RmfwJslwxfZjuAtGyusGvFnCzuDH6SIYTfkPuFSsHsKe3cCdg==",
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.17.tgz",
+      "integrity": "sha512-u74a41l3NwkJIfSSJc1aWz9nzY/a8mVWdQ2bT0VuZmmyOCqVu/nTDHg5Emv14Kj5Os3u/OtjtcRa+PQTXRzgfA==",
       "dev": true
     },
     "JSONStream": {
@@ -700,9 +701,9 @@
       }
     },
     "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -712,9 +713,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
+      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
       "dev": true
     },
     "amdefine": {
@@ -773,9 +774,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -959,9 +960,9 @@
       "dev": true
     },
     "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assertion-error": {
@@ -989,17 +990,17 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000727",
+        "caniuse-db": "1.0.30000748",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "5.2.17",
+        "postcss": "5.2.18",
         "postcss-value-parser": "3.3.0"
       }
     },
     "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
@@ -1060,14 +1061,25 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
+        "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "babel-generator": {
@@ -1111,15 +1123,15 @@
       }
     },
     "babel-helper-evaluate-path": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.0.3.tgz",
-      "integrity": "sha1-HRA6ydSlnl1DGEIhLxUXhfesVHs=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.2.0.tgz",
+      "integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg==",
       "dev": true
     },
     "babel-helper-flip-expressions": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.0.2.tgz",
-      "integrity": "sha1-e6ss9hFivJJwPpspjvUSvPd9Z4c=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.2.0.tgz",
+      "integrity": "sha512-rAsPA1pWBc7e2E6HepkP2e1sXugT+Oq/VCqhyuHJ8aJ2d/ifwnJfd4Qxjm21qlW43AN8tqaeByagKK6wECFMSw==",
       "dev": true
     },
     "babel-helper-function-name": {
@@ -1162,15 +1174,15 @@
       "dev": true
     },
     "babel-helper-is-void-0": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.0.1.tgz",
-      "integrity": "sha1-7XRVO4g+aCJq5F+YmpmwLBkPEFo=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.2.0.tgz",
+      "integrity": "sha512-Axj1AYuD0E3Dl7nT3KxROP7VekEofz3XtEljzURf3fABalLpr8PamtgLFt+zuxtaCxRf9iuZmbAMMYWri5Bazw==",
       "dev": true
     },
     "babel-helper-mark-eval-scopes": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.1.1.tgz",
-      "integrity": "sha1-RVQ0Xt+fJUlCe9IJjlMCU/ivKZI=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.2.0.tgz",
+      "integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw==",
       "dev": true
     },
     "babel-helper-optimise-call-expression": {
@@ -1195,9 +1207,9 @@
       }
     },
     "babel-helper-remove-or-void": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.1.1.tgz",
-      "integrity": "sha1-nX4YVtxvr8tBsoOkFnMNwYRPZtc=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.2.0.tgz",
+      "integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA==",
       "dev": true
     },
     "babel-helper-replace-supers": {
@@ -1215,9 +1227,9 @@
       }
     },
     "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.0.3.tgz",
-      "integrity": "sha1-x4mg+szSZpxRI0vizqej5aBXPCU=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.2.0.tgz",
+      "integrity": "sha512-ij9lpfdP3+Zc/7kNwa+NXbTrUlsYEWPwt/ugmQO0qflzLrveTIkbfOqQztvitk81aG5NblYDQXDlRohzu3oa8Q==",
       "dev": true
     },
     "babel-helpers": {
@@ -1257,86 +1269,99 @@
         "babel-runtime": "6.26.0"
       }
     },
-    "babel-plugin-minify-constant-folding": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.0.3.tgz",
-      "integrity": "sha1-pRHoOVYkiYEZh6elA8Q8MSxAE4o=",
+    "babel-plugin-minify-builtins": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.2.0.tgz",
+      "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.0.3"
+        "babel-helper-evaluate-path": "0.2.0"
+      }
+    },
+    "babel-plugin-minify-constant-folding": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.2.0.tgz",
+      "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0"
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.1.7.tgz",
-      "integrity": "sha1-d09TbzR7mDk6J7qnF4cpaIE8NCw=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.2.0.tgz",
+      "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
       "dev": true,
       "requires": {
-        "babel-helper-mark-eval-scopes": "0.1.1",
-        "babel-helper-remove-or-void": "0.1.1",
+        "babel-helper-evaluate-path": "0.2.0",
+        "babel-helper-mark-eval-scopes": "0.2.0",
+        "babel-helper-remove-or-void": "0.2.0",
         "lodash.some": "4.6.0"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.0.2.tgz",
-      "integrity": "sha1-fQlTqlh27eYRiWa9qe3sxjvzRqs=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.2.0.tgz",
+      "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.0.1"
+        "babel-helper-is-void-0": "0.2.0"
       }
     },
     "babel-plugin-minify-guarded-expressions": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.0.4.tgz",
-      "integrity": "sha1-lXEEp2Dmp//ZZwBaehFiG7Qv0Rw=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.2.0.tgz",
+      "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.0.2"
+        "babel-helper-flip-expressions": "0.2.0"
       }
     },
     "babel-plugin-minify-infinity": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.0.3.tgz",
-      "integrity": "sha1-TMmbYdErQ0zoCtZ1EDM1xYnLqaE=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.2.0.tgz",
+      "integrity": "sha512-U694vrla1lN6vDHWGrR832t3a/A2eh+kyl019LxEE2+sS4VTydyOPRsAOIYAdJegWRA4cMX1lm9azAN0cLIr8g==",
       "dev": true
     },
     "babel-plugin-minify-mangle-names": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.0.6.tgz",
-      "integrity": "sha1-cxHoIpLVrdk8qAxOz73p6KlzCkM=",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.2.0.tgz",
+      "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-mark-eval-scopes": "0.2.0"
+      }
     },
     "babel-plugin-minify-numeric-literals": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.0.1.tgz",
-      "integrity": "sha1-lZfmwxFU19rzdE0L1BfBRLJ1vVM=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.2.0.tgz",
+      "integrity": "sha512-VcLpb+r1YS7+RIOXdRsFVLLqoh22177USpHf+JM/g1nZbzdqENmfd5v534MLAbRErhbz6SyK+NQViVzVtBxu8g==",
       "dev": true
     },
     "babel-plugin-minify-replace": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.0.1.tgz",
-      "integrity": "sha1-XVrqfLmJkkUkjR7pznov5Vao+sw=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.2.0.tgz",
+      "integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q==",
       "dev": true
     },
     "babel-plugin-minify-simplify": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.0.6.tgz",
-      "integrity": "sha1-HVCJmynDxFA+rvuYNlzF96hK7f4=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.2.0.tgz",
+      "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.0.2",
+        "babel-helper-flip-expressions": "0.2.0",
         "babel-helper-is-nodes-equiv": "0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "0.0.3"
+        "babel-helper-to-multiple-sequence-expressions": "0.2.0"
       }
     },
     "babel-plugin-minify-type-constructors": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.0.3.tgz",
-      "integrity": "sha1-q1nBrYNba26OkyuHXU303Dk9nSY=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.2.0.tgz",
+      "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.0.1"
+        "babel-helper-is-void-0": "0.2.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1574,9 +1599,9 @@
       }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.0.2.tgz",
-      "integrity": "sha1-pY/Oz8CcCPv5NzpaPnB0bAPQH8E=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.2.0.tgz",
+      "integrity": "sha512-GlhOuLOQ28ua9prg0hT33HslCrEmz9xWXy9ZNZSACppCyRxxRW+haYtRgm7uYXCcd0q8ggCWD2pfWEJp5iiZfQ==",
       "dev": true
     },
     "babel-plugin-transform-member-expression-literals": {
@@ -1616,9 +1641,9 @@
       }
     },
     "babel-plugin-transform-regexp-constructors": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.0.5.tgz",
-      "integrity": "sha1-dNleDFZ+b8HZxpmghIlNQN6OWB0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.2.0.tgz",
+      "integrity": "sha512-7IsQ6aQx6LAaOqy97/PthTf+5Nx9grZww3r6E62IdWe76Yr8KsuwVjxzqSPQvESJqTE3EMADQ9S0RtwWDGNG9Q==",
       "dev": true
     },
     "babel-plugin-transform-remove-console": {
@@ -1634,10 +1659,13 @@
       "dev": true
     },
     "babel-plugin-transform-remove-undefined": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.0.4.tgz",
-      "integrity": "sha1-zHW+BLm717sgBScswWC00IaS13w=",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.2.0.tgz",
+      "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.2.0"
+      }
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.8.5",
@@ -1660,36 +1688,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.8.3.tgz",
       "integrity": "sha512-goYwp8dMrzHD6x9GjZ2M85Mk2vxf1h85CnUgAjfftUnlJvzF4uj5MrbReHBTbjQ96C8CuRzvhYZ3tv8H3Sc1ZA==",
       "dev": true
-    },
-    "babel-preset-babili": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/babel-preset-babili/-/babel-preset-babili-0.0.10.tgz",
-      "integrity": "sha1-WRGJJLd7iY7s2PdaW5fWlHGUQ/8=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-minify-constant-folding": "0.0.3",
-        "babel-plugin-minify-dead-code-elimination": "0.1.7",
-        "babel-plugin-minify-flip-comparisons": "0.0.2",
-        "babel-plugin-minify-guarded-expressions": "0.0.4",
-        "babel-plugin-minify-infinity": "0.0.3",
-        "babel-plugin-minify-mangle-names": "0.0.6",
-        "babel-plugin-minify-numeric-literals": "0.0.1",
-        "babel-plugin-minify-replace": "0.0.1",
-        "babel-plugin-minify-simplify": "0.0.6",
-        "babel-plugin-minify-type-constructors": "0.0.3",
-        "babel-plugin-transform-inline-consecutive-adds": "0.0.2",
-        "babel-plugin-transform-member-expression-literals": "6.8.5",
-        "babel-plugin-transform-merge-sibling-variables": "6.8.6",
-        "babel-plugin-transform-minify-booleans": "6.8.3",
-        "babel-plugin-transform-property-literals": "6.8.5",
-        "babel-plugin-transform-regexp-constructors": "0.0.5",
-        "babel-plugin-transform-remove-console": "6.8.5",
-        "babel-plugin-transform-remove-debugger": "6.8.5",
-        "babel-plugin-transform-remove-undefined": "0.0.4",
-        "babel-plugin-transform-simplify-comparison-operators": "6.8.5",
-        "babel-plugin-transform-undefined-to-void": "6.8.3",
-        "lodash.isplainobject": "4.0.6"
-      }
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
@@ -1721,6 +1719,37 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0"
+      }
+    },
+    "babel-preset-minify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz",
+      "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-minify-builtins": "0.2.0",
+        "babel-plugin-minify-constant-folding": "0.2.0",
+        "babel-plugin-minify-dead-code-elimination": "0.2.0",
+        "babel-plugin-minify-flip-comparisons": "0.2.0",
+        "babel-plugin-minify-guarded-expressions": "0.2.0",
+        "babel-plugin-minify-infinity": "0.2.0",
+        "babel-plugin-minify-mangle-names": "0.2.0",
+        "babel-plugin-minify-numeric-literals": "0.2.0",
+        "babel-plugin-minify-replace": "0.2.0",
+        "babel-plugin-minify-simplify": "0.2.0",
+        "babel-plugin-minify-type-constructors": "0.2.0",
+        "babel-plugin-transform-inline-consecutive-adds": "0.2.0",
+        "babel-plugin-transform-member-expression-literals": "6.8.5",
+        "babel-plugin-transform-merge-sibling-variables": "6.8.6",
+        "babel-plugin-transform-minify-booleans": "6.8.3",
+        "babel-plugin-transform-property-literals": "6.8.5",
+        "babel-plugin-transform-regexp-constructors": "0.2.0",
+        "babel-plugin-transform-remove-console": "6.8.5",
+        "babel-plugin-transform-remove-debugger": "6.8.5",
+        "babel-plugin-transform-remove-undefined": "0.2.0",
+        "babel-plugin-transform-simplify-comparison-operators": "6.8.5",
+        "babel-plugin-transform-undefined-to-void": "6.8.3",
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "babel-register": {
@@ -1772,10 +1801,21 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "babel-types": {
@@ -1874,34 +1914,31 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.0.tgz",
-      "integrity": "sha1-07Ik1Gf6LOjUNYnAJFBDJnwJNjQ=",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.3",
-        "debug": "2.6.8",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "http-errors": "1.6.2",
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "on-finished": "2.3.0",
-        "qs": "6.5.0",
-        "raw-body": "2.3.1",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
         "type-is": "1.6.15"
       },
       "dependencies": {
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-          "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
-          "dev": true
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -1912,12 +1949,12 @@
       "dev": true
     },
     "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "bower": {
@@ -2026,6 +2063,16 @@
         "repeat-element": "1.1.2"
       }
     },
+    "browser-capabilities": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-0.2.1.tgz",
+      "integrity": "sha512-huj8A1CGx28XvsgZvbkjWul+sR3NqQHr0FOvq6GcOWFJ7n4eKBOSNzmmPCRbA49bV5W8P7cbN5274fvsTEL7hw==",
+      "dev": true,
+      "requires": {
+        "@types/ua-parser-js": "0.7.32",
+        "ua-parser-js": "0.7.17"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -2047,8 +2094,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000727",
-        "electron-to-chromium": "1.3.21"
+        "caniuse-db": "1.0.30000748",
+        "electron-to-chromium": "1.3.26"
       }
     },
     "browserstack": {
@@ -2110,9 +2157,9 @@
       }
     },
     "bytes": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-      "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "caller-path": {
@@ -2163,15 +2210,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000727",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000727.tgz",
-      "integrity": "sha1-TiJZMImw81wbKtz8KCNEk6IaSy4=",
+      "version": "1.0.30000748",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000748.tgz",
+      "integrity": "sha1-eF2e381kW/eVxv887TPEXVgMSKA=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000727",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000727.tgz",
-      "integrity": "sha1-IMiVdoOY3tX5ikvqtKdsKF3vQdI=",
+      "version": "1.0.30000748",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000748.tgz",
+      "integrity": "sha1-RMjW2lKtZaXXudyk7+vQvdmCugk=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2198,14 +2245,14 @@
       }
     },
     "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+      "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
+        "supports-color": "4.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2218,9 +2265,9 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -2349,9 +2396,9 @@
       }
     },
     "clean-css": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.8.tgz",
-      "integrity": "sha1-BhRVsklKdQrJj0bY1euxfGeeqdE=",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
@@ -2519,7 +2566,7 @@
         "object-assign": "4.1.1",
         "pipetteur": "2.0.3",
         "plur": "2.1.2",
-        "postcss": "5.2.17",
+        "postcss": "5.2.18",
         "postcss-reporter": "1.4.1",
         "text-table": "0.2.0",
         "yargs": "1.3.3"
@@ -2547,7 +2594,7 @@
             "chalk": "1.1.3",
             "lodash": "4.17.4",
             "log-symbols": "1.0.2",
-            "postcss": "5.2.17"
+            "postcss": "5.2.18"
           }
         },
         "strip-ansi": {
@@ -2648,9 +2695,9 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
-      "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
@@ -2669,18 +2716,29 @@
       }
     },
     "compression": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
-      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
-        "bytes": "2.5.0",
+        "bytes": "3.0.0",
         "compressible": "2.0.11",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.1"
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "concat-map": {
@@ -2724,9 +2782,9 @@
       "dev": true
     },
     "content-type": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.3.tgz",
-      "integrity": "sha1-2hjvL7ZMpqzJBcxyAX0/OBhbkdE=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "convert-source-map": {
@@ -2794,14 +2852,14 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.4.4",
+        "crc": "3.5.0",
         "readable-stream": "2.3.3"
       },
       "dependencies": {
         "crc": {
-          "version": "3.4.4",
-          "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
-          "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms=",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+          "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
           "dev": true
         }
       }
@@ -2833,12 +2891,23 @@
       "dev": true
     },
     "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        }
       }
     },
     "css-color-names": {
@@ -2919,15 +2988,16 @@
       }
     },
     "css-slam": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/css-slam/-/css-slam-1.2.1.tgz",
-      "integrity": "sha1-JGflrst+mJvQT2VgEd0c+Os+cWU=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/css-slam/-/css-slam-2.0.2.tgz",
+      "integrity": "sha512-4cFIlPuteucnKCZa68rB/Pd3uV+DDc7UwP3PVmlEwxTi92WdesRc9Ddbzw6/+RunF09tNK3sSkLERBFO1DjKcg==",
       "dev": true,
       "requires": {
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
-        "dom5": "1.3.6",
-        "shady-css-parser": "0.0.8"
+        "dom5": "2.3.0",
+        "parse5": "2.2.3",
+        "shady-css-parser": "0.1.0"
       }
     },
     "css-tokenize": {
@@ -3006,26 +3076,18 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -3087,7 +3149,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -3203,14 +3265,14 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000727",
+        "caniuse-db": "1.0.30000748",
         "css-rule-stream": "1.1.0",
         "duplexer2": "0.0.2",
         "jsonfilter": "1.1.2",
         "ldjson-stream": "1.2.1",
         "lodash": "4.17.4",
         "multimatch": "2.1.0",
-        "postcss": "5.2.17",
+        "postcss": "5.2.18",
         "source-map": "0.4.4",
         "through2": "0.6.5",
         "yargs": "3.32.0"
@@ -3329,26 +3391,32 @@
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "dev": true,
       "requires": {
-        "urijs": "1.18.12"
+        "urijs": "1.19.0"
       }
     },
     "dom5": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/dom5/-/dom5-1.3.6.tgz",
-      "integrity": "sha1-pwiKn8XzsI3J9u2kx6uuskGUXg0=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
+      "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
       "dev": true,
       "requires": {
         "@types/clone": "0.1.30",
-        "@types/node": "4.2.20",
-        "@types/parse5": "0.0.31",
-        "clone": "1.0.2",
-        "parse5": "1.5.1"
+        "@types/node": "6.0.90",
+        "@types/parse5": "2.2.34",
+        "clone": "2.1.1",
+        "parse5": "2.2.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "4.2.20",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.20.tgz",
-          "integrity": "sha512-nSLKvYxEIV2bBlWvvpas2z7tKkg2qfkx2BdotvL1rkhbStlijGajd9+db8fghja1citNOa9cOVn20JQ6ImP9tg==",
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
+          "dev": true
+        },
+        "clone": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
         }
       }
@@ -3486,9 +3554,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.21",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz",
-      "integrity": "sha1-qWfr3P6O0Ag/wkTRiUAiqOgRPqI=",
+      "version": "1.3.26",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.26.tgz",
+      "integrity": "sha1-mWQnKUhhp02cfIK5Jg6jAejALWY=",
       "dev": true
     },
     "encodeurl": {
@@ -3696,20 +3764,20 @@
       }
     },
     "eslint": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.6.1.tgz",
-      "integrity": "sha1-3cf8f9cL+TIFsLNEm7FqHp59SVA=",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.9.0.tgz",
+      "integrity": "sha1-doedJ0BoJhsZH+Dy9Wx0wvQgjos=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.2.3",
         "babel-code-frame": "6.26.0",
-        "chalk": "2.1.0",
+        "chalk": "2.2.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
+        "debug": "3.1.0",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -3719,7 +3787,7 @@
         "globals": "9.18.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.3",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
@@ -3730,26 +3798,26 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
-        "table": "4.0.1",
+        "table": "4.0.2",
         "text-table": "0.2.0"
       }
     },
     "eslint-config-vaadin": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-vaadin/-/eslint-config-vaadin-0.2.4.tgz",
-      "integrity": "sha512-vHpGyCt3moo+Zr1kgD8Du0kl/F1wbpGyKpRhBMP52i0nbkDW+S0S9F0UqL7dyoX3h6oUsu9n0fdx5fD2RKrUxw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-vaadin/-/eslint-config-vaadin-0.2.5.tgz",
+      "integrity": "sha512-tu0NTuLT03vk0eYIWbKBsO4ew0+IwLxniblkns82F4XOfHUskIaTd/YhaiTUiC27esL18b71FCmhpFAuzrI+kQ==",
       "dev": true
     },
     "eslint-plugin-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-3.2.1.tgz",
-      "integrity": "sha512-zxcArJx7QTqE0Stm5BMpk1cuYwOxLecqKMqEYabRcvqImDrjcRdQVdXT5RtqFHdH1aVD2akzHe+/Q5Wou6Jvaw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-3.2.2.tgz",
+      "integrity": "sha512-sSuafathF6ImPrzF2vUKEJY6Llq06d/riMTMzlsruDRDhNsQMYp2viUKo+jx+JRr1QevskeUpQcuptp2gN1XVQ==",
       "dev": true,
       "requires": {
         "htmlparser2": "3.9.2",
@@ -3767,9 +3835,9 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
         "acorn": "5.1.2",
@@ -3814,9 +3882,9 @@
       "dev": true
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter3": {
@@ -3883,46 +3951,51 @@
       }
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.3",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.4",
-        "fresh": "0.5.0",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
       },
       "dependencies": {
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "path-to-regexp": {
           "version": "0.1.7",
@@ -3931,20 +4004,20 @@
           "dev": true
         },
         "send": {
-          "version": "0.15.4",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
           "dev": true,
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "depd": "1.1.1",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
-            "etag": "1.8.0",
-            "fresh": "0.5.0",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
             "http-errors": "1.6.2",
-            "mime": "1.3.4",
+            "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
@@ -3990,14 +4063,14 @@
       }
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.19",
         "jschardet": "1.5.1",
-        "tmp": "0.0.31"
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -4101,7 +4174,7 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
+        "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
       }
     },
@@ -4131,18 +4204,29 @@
       "dev": true
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "find-index": {
@@ -4237,9 +4321,9 @@
       "dev": true
     },
     "flat-cache": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
         "circular-json": "0.3.3",
@@ -4260,8 +4344,19 @@
       "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "stream-consume": "0.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -4292,9 +4387,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
@@ -4312,9 +4407,9 @@
       }
     },
     "forwarded": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.1.tgz",
-      "integrity": "sha1-ik4wxkCwU5U5mjVJxzAldygEiWE=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "freeport": {
@@ -4325,9 +4420,9 @@
       "optional": true
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-exists-sync": {
@@ -4403,14 +4498,6 @@
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "gh-got": {
@@ -4464,7 +4551,7 @@
       "requires": {
         "follow-redirects": "0.0.7",
         "https-proxy-agent": "1.0.0",
-        "mime": "1.4.0",
+        "mime": "1.4.1",
         "netrc": "0.1.4"
       }
     },
@@ -4785,7 +4872,7 @@
         "chalk": "1.1.3",
         "deprecated": "0.0.1",
         "gulp-util": "3.0.8",
-        "interpret": "1.0.3",
+        "interpret": "1.0.4",
         "liftoff": "2.3.0",
         "minimist": "1.2.0",
         "orchestrator": "0.3.8",
@@ -4838,7 +4925,7 @@
       "integrity": "sha512-+qsePo04v1O3JshpNvww9+bOgZEJ6Cc2/w3mEktfKz0NL0zsh1SWzjyIL2FIM2zzy6IYQYv+j8REZORF8dKX4g==",
       "dev": true,
       "requires": {
-        "eslint": "4.6.1",
+        "eslint": "4.9.0",
         "gulp-util": "3.0.8"
       }
     },
@@ -5113,6 +5200,15 @@
             "supports-color": "2.0.0"
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "get-stdin": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
@@ -5155,10 +5251,10 @@
           "requires": {
             "autoprefixer": "6.7.7",
             "balanced-match": "0.4.2",
-            "chalk": "2.1.0",
+            "chalk": "2.2.0",
             "colorguard": "1.2.0",
             "cosmiconfig": "2.2.2",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "doiuse": "2.6.0",
             "execall": "1.0.0",
             "file-entry-cache": "2.0.0",
@@ -5176,7 +5272,7 @@
             "micromatch": "2.3.11",
             "normalize-selector": "0.2.0",
             "pify": "2.3.0",
-            "postcss": "5.2.17",
+            "postcss": "5.2.18",
             "postcss-less": "0.14.0",
             "postcss-media-query-parser": "0.2.3",
             "postcss-reporter": "3.0.0",
@@ -5185,13 +5281,13 @@
             "postcss-selector-parser": "2.2.3",
             "postcss-value-parser": "3.3.0",
             "resolve-from": "3.0.0",
-            "specificity": "0.3.1",
+            "specificity": "0.3.2",
             "string-width": "2.1.1",
             "style-search": "0.1.0",
             "stylehacks": "2.3.2",
             "sugarss": "0.2.0",
             "svg-tags": "1.0.0",
-            "table": "4.0.1"
+            "table": "4.0.2"
           },
           "dependencies": {
             "ansi-styles": {
@@ -5204,20 +5300,20 @@
               }
             },
             "chalk": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.0.tgz",
+              "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
               "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "4.4.0"
+                "supports-color": "4.5.0"
               }
             },
             "supports-color": {
-              "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-              "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
               "dev": true,
               "requires": {
                 "has-flag": "2.0.0"
@@ -5237,7 +5333,7 @@
         "array-uniq": "1.0.3",
         "beeper": "1.1.1",
         "chalk": "1.1.3",
-        "dateformat": "2.0.0",
+        "dateformat": "2.2.0",
         "fancy-log": "1.3.0",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
@@ -5319,31 +5415,19 @@
       "dev": true
     },
     "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        }
+        "ajv": "5.2.3",
+        "har-schema": "2.0.0"
       }
     },
     "has-ansi": {
@@ -5400,15 +5484,15 @@
       }
     },
     "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
       }
     },
     "he": {
@@ -5418,9 +5502,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
       "dev": true
     },
     "home-or-tmp": {
@@ -5461,19 +5545,19 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.4.tgz",
-      "integrity": "sha512-kzvy0Lvs4anPdqWgeXiLisMqAKyHwgajAQaarzwZJHkTU40/Cbqup873U2WtPem8uPbGddVnPes3wtfzQz3+hg==",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.6.tgz",
+      "integrity": "sha512-88FjtKrlak2XjczhxrBomgzV4jmGzM3UnHRBScRkJcmcRum0kb+IwhVAETJ8AVp7j0p3xugjSaw9L+RmI5/QOA==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.8",
+        "clean-css": "4.1.9",
         "commander": "2.11.0",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.1.0"
+        "uglify-js": "3.1.4"
       }
     },
     "html-tags": {
@@ -5512,6 +5596,14 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
       }
     },
     "http-proxy": {
@@ -5554,12 +5646,12 @@
       }
     },
     "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
+        "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
@@ -5571,8 +5663,19 @@
       "dev": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -5637,16 +5740,16 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
-      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "2.0.0",
-        "chalk": "2.1.0",
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.2.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "2.0.4",
+        "external-editor": "2.0.5",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -5659,9 +5762,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
     "intersect": {
@@ -5686,15 +5789,15 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
     "irregular-plurals": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
     "is-absolute": {
@@ -6021,9 +6124,9 @@
       }
     },
     "js-base64": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.1.tgz",
-      "integrity": "sha512-cEao+Mb0czmVPzywx6+Cd0vmTAZrHJl92xqNlrLj8KpDhi7FfQ6jECH7DeQ27MAPQRSJXpPSMhqisO7N4712Ww==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
+      "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw==",
       "dev": true
     },
     "js-tokens": {
@@ -6188,14 +6291,6 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "kind-of": {
@@ -6231,7 +6326,7 @@
       "requires": {
         "async": "2.5.0",
         "browserstack": "1.5.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "plist": "2.1.0",
         "q": "1.5.0",
         "underscore": "1.8.3"
@@ -6245,6 +6340,16 @@
           "optional": true,
           "requires": {
             "lodash": "4.17.4"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "underscore": {
@@ -6857,7 +6962,7 @@
         "globby": "6.1.0",
         "mkdirp": "0.5.1",
         "multimatch": "2.1.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "through2": "2.0.3",
         "vinyl": "2.1.0"
       },
@@ -6978,9 +7083,9 @@
       }
     },
     "mime": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz",
-      "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -7044,9 +7149,9 @@
       }
     },
     "mocha": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.2.tgz",
-      "integrity": "sha512-iH5zl7afRZl1GvD0pnrRlazgc9Z/o34pXWmTFi8xNIMFKXgNL1SoBTDDb9sJfbV/sJV/j8X+0gvwY1QS1He7Nw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -7070,6 +7175,15 @@
           "dev": true,
           "requires": {
             "graceful-readlink": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "glob": {
@@ -7161,9 +7275,9 @@
       "dev": true
     },
     "mz": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
-      "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -7555,6 +7669,12 @@
         "p-limit": "1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
     "package-json": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
@@ -7621,9 +7741,9 @@
       "dev": true
     },
     "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+      "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
       "dev": true
     },
     "parsejson": {
@@ -7752,13 +7872,14 @@
       }
     },
     "pem": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.10.0.tgz",
-      "integrity": "sha1-tc7WLVI4bCSTy7UTE7pQTikdOeo=",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.12.3.tgz",
+      "integrity": "sha512-hT7GwvQL35+0iqgYUl8vn5I5pAVR0HcJas07TXL8bNaR4c5kAFRquk4ZqQk1F9YMcQOr6WjGdY5OnDC0RBnzig==",
       "dev": true,
       "requires": {
         "md5": "2.2.1",
         "os-tmpdir": "1.0.2",
+        "safe-buffer": "5.1.1",
         "which": "1.3.0"
       }
     },
@@ -7770,9 +7891,9 @@
       "optional": true
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
@@ -7824,13 +7945,13 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "1.3.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "plylog": {
@@ -7839,13 +7960,13 @@
       "integrity": "sha1-2ODOzEz+bDTREJ4Onaqib+6NS3M=",
       "dev": true,
       "requires": {
-        "winston": "2.3.1"
+        "winston": "2.4.0"
       }
     },
     "polymer-analyzer": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.2.2.tgz",
-      "integrity": "sha512-8kwxAAx95AMJbDQ1x6vKyCkTDnowG5q1nn8gPf91PP+GNgQhgVRPBeLZQzpPyHY7dplvOyEoBhtjZvaQDg5teA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.3.0.tgz",
+      "integrity": "sha512-mgvLJ7hez52/Iy54GGFVRs9CoO0jXWeS2Iqows5GJpL+KnFiR1afziI2s/5teQcC53vtPUtWba8PEeQHroD5Hw==",
       "dev": true,
       "requires": {
         "@types/chai-subset": "1.3.1",
@@ -7854,8 +7975,9 @@
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
         "@types/escodegen": "0.0.2",
-        "@types/estree": "0.0.34",
-        "@types/node": "6.0.88",
+        "@types/estraverse": "0.0.6",
+        "@types/estree": "0.0.37",
+        "@types/node": "6.0.90",
         "@types/parse5": "2.2.34",
         "chalk": "1.1.3",
         "clone": "2.1.1",
@@ -7863,28 +7985,19 @@
         "doctrine": "2.0.0",
         "dom5": "2.3.0",
         "escodegen": "1.9.0",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "estraverse": "4.2.0",
         "jsonschema": "1.2.0",
         "parse5": "2.2.3",
-        "shady-css-parser": "0.0.8",
+        "shady-css-parser": "0.1.0",
         "strip-indent": "2.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
           "dev": true
-        },
-        "@types/parse5": {
-          "version": "2.2.34",
-          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-          "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.88"
-          }
         },
         "chalk": {
           "version": "1.1.3",
@@ -7905,25 +8018,6 @@
           "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
         },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "dev": true,
-          "requires": {
-            "@types/clone": "0.1.30",
-            "@types/node": "6.0.88",
-            "@types/parse5": "2.2.34",
-            "clone": "2.1.1",
-            "parse5": "2.2.3"
-          }
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-          "dev": true
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -7942,23 +8036,23 @@
       }
     },
     "polymer-build": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-2.0.0.tgz",
-      "integrity": "sha512-3m5BiEBZBYV3+tHk5OBgxypfQBkP3MuYpp8UbdQblf2uR1JopyWsLw55xbxdCpHqbjG0/KqSE9FcHx+ZGRKpkQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-2.1.0.tgz",
+      "integrity": "sha512-1I/bS4Jz6ed7WXDHES+mJ4v1hdexYZlMDvf2pmO1JvO2WwxUG4tlEdyhxn0T6jG7lES8y3NEfrB44/wilkpATQ==",
       "dev": true,
       "requires": {
         "@types/mz": "0.0.31",
-        "@types/node": "6.0.88",
+        "@types/node": "6.0.90",
         "@types/parse5": "2.2.34",
         "@types/vinyl": "2.0.1",
         "@types/vinyl-fs": "0.0.28",
         "dom5": "2.3.0",
         "multipipe": "1.0.2",
-        "mz": "2.6.0",
+        "mz": "2.7.0",
         "parse5": "2.2.3",
         "plylog": "0.5.0",
-        "polymer-analyzer": "2.2.2",
-        "polymer-bundler": "3.0.1",
+        "polymer-analyzer": "2.3.0",
+        "polymer-bundler": "3.1.0",
         "polymer-project-config": "3.4.0",
         "sw-precache": "5.2.0",
         "vinyl": "1.2.0",
@@ -7966,38 +8060,10 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
           "dev": true
-        },
-        "@types/parse5": {
-          "version": "2.2.34",
-          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-          "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.88"
-          }
-        },
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-          "dev": true
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "dev": true,
-          "requires": {
-            "@types/clone": "0.1.30",
-            "@types/node": "6.0.88",
-            "@types/parse5": "2.2.34",
-            "clone": "2.1.1",
-            "parse5": "2.2.3"
-          }
         },
         "duplexer2": {
           "version": "0.1.4",
@@ -8112,27 +8178,21 @@
             "readable-stream": "2.3.3"
           }
         },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-          "dev": true
-        },
         "plylog": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
           "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
           "dev": true,
           "requires": {
-            "@types/node": "4.2.20",
-            "@types/winston": "2.3.5",
-            "winston": "2.3.1"
+            "@types/node": "4.2.21",
+            "@types/winston": "2.3.6",
+            "winston": "2.4.0"
           },
           "dependencies": {
             "@types/node": {
-              "version": "4.2.20",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.20.tgz",
-              "integrity": "sha512-nSLKvYxEIV2bBlWvvpas2z7tKkg2qfkx2BdotvL1rkhbStlijGajd9+db8fghja1citNOa9cOVn20JQ6ImP9tg==",
+              "version": "4.2.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.21.tgz",
+              "integrity": "sha512-j1cTTWBkbf1EyDAaGkvIRMrZQm4F3j071nDoOBRLuYc3JFkmCXm/dworx9P0WNS6c/X+siGIogkO6Kshw3gHWQ==",
               "dev": true
             }
           }
@@ -8171,14 +8231,6 @@
             "clone": "1.0.2",
             "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
-          },
-          "dependencies": {
-            "clone": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-              "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-              "dev": true
-            }
           }
         },
         "vinyl-fs": {
@@ -8209,124 +8261,90 @@
       }
     },
     "polymer-bundler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-3.0.1.tgz",
-      "integrity": "sha512-nimtMd5n+PfrKqSlJCx4dXUJLoocZ79/rce7OvV6CraQjWP/waPcIYbIQfUm0NGz8LqCJlyu5SN+IIbv0HNLIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-3.1.0.tgz",
+      "integrity": "sha512-iBeqzoapRTMernTeoaJSAzmsJtCRNV5CRpUoncZCs+P80x6SX0YMxANPcTEWha4GtIQmo+suNVE4DdMm5oTJ4Q==",
       "dev": true,
       "requires": {
         "clone": "2.1.1",
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
         "dom5": "2.3.0",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "mkdirp": "0.5.1",
         "parse5": "2.2.3",
-        "polymer-analyzer": "2.2.2",
+        "polymer-analyzer": "2.3.0",
         "source-map": "0.5.7"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-          "dev": true
-        },
-        "@types/parse5": {
-          "version": "2.2.34",
-          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-          "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.88"
-          }
-        },
         "clone": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
           "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
           "dev": true
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "dev": true,
-          "requires": {
-            "@types/clone": "0.1.30",
-            "@types/node": "6.0.88",
-            "@types/parse5": "2.2.34",
-            "clone": "2.1.1",
-            "parse5": "2.2.3"
-          }
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-          "dev": true
         }
       }
     },
     "polymer-cli": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/polymer-cli/-/polymer-cli-1.5.4.tgz",
-      "integrity": "sha512-qVMGshUXfEmcYD0cDSqf23H2CmSRE8MpyxYkrHOhXCZJrXgVk8M5ks7xYFq9kkg726txMIbFhzLqTvXZQV/+gg==",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/polymer-cli/-/polymer-cli-1.5.7.tgz",
+      "integrity": "sha512-J2baUW9jknyB9wNIUo+TAaPzJvnRO4jrUx8Qn81zQCccLERlhmjTQukyjYLy+gXOejbLnIgdjhxWL5cQZwkwnQ==",
       "dev": true,
       "requires": {
         "@types/babel-core": "6.25.2",
         "@types/chalk": "0.4.31",
-        "@types/del": "2.2.33",
+        "@types/del": "3.0.0",
         "@types/findup-sync": "0.3.29",
         "@types/gulp-if": "0.0.30",
         "@types/html-minifier": "1.1.30",
         "@types/inquirer": "0.0.32",
         "@types/merge-stream": "1.0.28",
         "@types/mz": "0.0.31",
-        "@types/request": "0.0.39",
+        "@types/request": "2.0.3",
         "@types/resolve": "0.0.4",
         "@types/rimraf": "0.0.28",
         "@types/semver": "5.4.0",
-        "@types/temp": "0.8.29",
+        "@types/temp": "0.8.30",
         "@types/update-notifier": "1.0.2",
         "@types/vinyl": "2.0.1",
         "@types/vinyl-fs": "0.0.28",
-        "@types/yeoman-generator": "1.0.3",
+        "@types/yeoman-generator": "1.0.4",
         "babel-core": "6.26.0",
         "babel-plugin-external-helpers": "6.22.0",
-        "babel-preset-babili": "0.0.10",
         "babel-preset-es2015": "6.24.1",
-        "bower": "1.8.0",
+        "babel-preset-minify": "0.2.0",
+        "bower": "1.8.2",
         "bower-json": "0.8.1",
         "bower-logger": "0.2.2",
         "chalk": "1.1.3",
         "command-line-args": "3.0.5",
         "command-line-commands": "1.0.4",
         "command-line-usage": "3.0.8",
-        "css-slam": "1.2.1",
-        "del": "2.2.2",
+        "css-slam": "2.0.2",
+        "del": "3.0.0",
         "findup-sync": "0.4.3",
         "github": "7.3.2",
         "gulp-if": "2.0.2",
         "gunzip-maybe": "1.4.1",
-        "html-minifier": "3.5.4",
+        "html-minifier": "3.5.6",
         "inquirer": "1.2.3",
         "merge-stream": "1.0.1",
-        "mz": "2.6.0",
+        "mz": "2.7.0",
         "plylog": "0.4.0",
-        "polymer-analyzer": "2.2.2",
-        "polymer-build": "2.0.0",
-        "polymer-linter": "2.0.3",
+        "polymer-analyzer": "2.3.0",
+        "polymer-build": "2.1.0",
+        "polymer-linter": "2.1.0",
         "polymer-project-config": "3.4.0",
-        "polyserve": "0.20.0",
-        "request": "2.81.0",
-        "rimraf": "2.6.1",
+        "polyserve": "0.23.0",
+        "request": "2.83.0",
+        "rimraf": "2.6.2",
         "semver": "5.4.1",
-        "tar-fs": "1.15.3",
+        "tar-fs": "1.16.0",
         "temp": "0.8.3",
         "update-notifier": "1.0.3",
         "vinyl": "1.2.0",
         "vinyl-fs": "2.4.4",
-        "web-component-tester": "6.1.5",
+        "web-component-tester": "6.3.0",
         "yeoman-environment": "1.6.6",
         "yeoman-generator": "1.1.1"
       },
@@ -8335,12 +8353,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "bower": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
-          "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo=",
           "dev": true
         },
         "chalk": {
@@ -8365,6 +8377,20 @@
             "restore-cursor": "1.0.1"
           }
         },
+        "del": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+          "dev": true,
+          "requires": {
+            "globby": "6.1.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "p-map": "1.2.0",
+            "pify": "3.0.0",
+            "rimraf": "2.6.2"
+          }
+        },
         "external-editor": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
@@ -8384,19 +8410,6 @@
           "requires": {
             "escape-string-regexp": "1.0.5",
             "object-assign": "4.1.1"
-          }
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -8425,6 +8438,19 @@
             "unique-stream": "2.2.1"
           },
           "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "dev": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
             "readable-stream": {
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -8446,6 +8472,27 @@
                 "readable-stream": "1.0.34",
                 "xtend": "4.0.1"
               }
+            }
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
             }
           }
         },
@@ -8522,6 +8569,12 @@
             "is-stream": "1.1.0",
             "readable-stream": "2.3.3"
           }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         },
         "restore-cursor": {
           "version": "1.0.1",
@@ -8626,61 +8679,33 @@
       }
     },
     "polymer-linter": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/polymer-linter/-/polymer-linter-2.0.3.tgz",
-      "integrity": "sha512-R+eC23lIr63leTn+hSr7fYwNkbYcPZdT2nHKZeCmIpLrbf/ie3cmZr6Drh8FAy2XcG5hUtdLeFaj5M1xfYPpGg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/polymer-linter/-/polymer-linter-2.1.0.tgz",
+      "integrity": "sha512-DW15SNEjJ9+LhYawBaWBTTRefCcwkZec6yp9ouFoILNANIJPiU8iQ2Hc7VmSoU9XniFFWwBIH1Y4BI6n7i0eBg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.34",
         "@types/fast-levenshtein": "0.0.1",
-        "@types/node": "6.0.88",
+        "@types/node": "6.0.90",
         "@types/parse5": "2.2.34",
         "dom5": "2.3.0",
         "estraverse": "4.2.0",
         "fast-levenshtein": "2.0.6",
         "parse5": "2.2.3",
-        "polymer-analyzer": "2.2.2",
+        "polymer-analyzer": "2.3.0",
         "strip-indent": "2.0.0"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "0.0.34",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.34.tgz",
+          "integrity": "sha1-qnr2mjqRkiFx7kEbPJ2Pa+tK8yE=",
+          "dev": true
+        },
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-          "dev": true
-        },
-        "@types/parse5": {
-          "version": "2.2.34",
-          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-          "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
-          "dev": true,
-          "requires": {
-            "@types/node": "6.0.88"
-          }
-        },
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-          "dev": true
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "dev": true,
-          "requires": {
-            "@types/clone": "0.1.30",
-            "@types/node": "6.0.88",
-            "@types/parse5": "2.2.34",
-            "clone": "2.1.1",
-            "parse5": "2.2.3"
-          }
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
           "dev": true
         },
         "strip-indent": {
@@ -8697,16 +8722,16 @@
       "integrity": "sha512-MhrStBi1lZvrk9Ia2ePGp8kHHiXO5Pjif6uznHp4iv1d3dVrrRRvCtgI7Wbv/wJAimZuJ+xdhLIsqB5HZT+Sfg==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.88",
+        "@types/node": "6.0.90",
         "jsonschema": "1.2.0",
         "minimatch-all": "1.1.0",
         "plylog": "0.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
           "dev": true
         },
         "plylog": {
@@ -8715,15 +8740,15 @@
           "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
           "dev": true,
           "requires": {
-            "@types/node": "4.2.20",
-            "@types/winston": "2.3.5",
-            "winston": "2.3.1"
+            "@types/node": "4.2.21",
+            "@types/winston": "2.3.6",
+            "winston": "2.4.0"
           },
           "dependencies": {
             "@types/node": {
-              "version": "4.2.20",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.20.tgz",
-              "integrity": "sha512-nSLKvYxEIV2bBlWvvpas2z7tKkg2qfkx2BdotvL1rkhbStlijGajd9+db8fghja1citNOa9cOVn20JQ6ImP9tg==",
+              "version": "4.2.21",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.21.tgz",
+              "integrity": "sha512-j1cTTWBkbf1EyDAaGkvIRMrZQm4F3j071nDoOBRLuYc3JFkmCXm/dworx9P0WNS6c/X+siGIogkO6Kshw3gHWQ==",
               "dev": true
             }
           }
@@ -8731,24 +8756,25 @@
       }
     },
     "polyserve": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.20.0.tgz",
-      "integrity": "sha512-i99n2lHz2Xuje7dRZAFx4DhLPLhZyDiiBz6QLaq0TmWEjqoDYsf/EFikemD2SEz8Cf4Q03Tn0E6EZ742KuXGhw==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.23.0.tgz",
+      "integrity": "sha512-ijzCbFttKG1F0hMTWWIzMoo+sxsfpXctoHFigw2ViBcvUt/aUBfJCUTHPKHhi/3zAgtw5Ej3SgoIOY9LflpXAw==",
       "dev": true,
       "requires": {
         "@types/assert": "0.0.29",
         "@types/babel-core": "6.25.2",
+        "@types/babylon": "6.16.2",
         "@types/compression": "0.0.33",
         "@types/content-type": "1.1.1",
         "@types/express": "4.0.37",
         "@types/mime": "0.0.29",
         "@types/mz": "0.0.29",
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.45",
         "@types/opn": "3.0.28",
         "@types/parse5": "2.2.34",
         "@types/pem": "1.9.2",
         "@types/serve-static": "1.7.32",
-        "@types/spdy": "3.4.2",
+        "@types/spdy": "3.4.4",
         "@types/ua-parser-js": "0.7.32",
         "babel-core": "6.26.0",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -8761,6 +8787,7 @@
         "babel-plugin-transform-es2015-for-of": "6.23.0",
         "babel-plugin-transform-es2015-function-name": "6.24.1",
         "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-plugin-transform-es2015-object-super": "6.24.1",
         "babel-plugin-transform-es2015-parameters": "6.24.1",
         "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
@@ -8770,25 +8797,27 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
+        "babylon": "6.18.0",
+        "browser-capabilities": "0.2.1",
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
-        "compression": "1.7.0",
-        "content-type": "1.0.3",
+        "compression": "1.7.1",
+        "content-type": "1.0.4",
         "dom5": "2.3.0",
-        "express": "4.15.4",
+        "express": "4.16.2",
         "find-port": "1.0.1",
         "http-proxy-middleware": "0.17.4",
         "lru-cache": "4.1.1",
-        "mime": "1.4.0",
-        "mz": "2.6.0",
+        "mime": "1.4.1",
+        "mz": "2.7.0",
         "opn": "3.0.3",
         "parse5": "2.2.3",
-        "pem": "1.10.0",
-        "polymer-build": "2.0.0",
+        "pem": "1.12.3",
+        "polymer-build": "2.1.0",
+        "requirejs": "2.3.5",
         "resolve": "1.4.0",
         "send": "0.14.2",
-        "spdy": "3.4.7",
-        "ua-parser-js": "0.7.14"
+        "spdy": "3.4.7"
       },
       "dependencies": {
         "@types/mz": {
@@ -8797,62 +8826,20 @@
           "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
           "dev": true,
           "requires": {
-            "@types/bluebird": "3.5.10",
-            "@types/node": "8.0.28"
+            "@types/bluebird": "3.5.16",
+            "@types/node": "8.0.45"
           }
-        },
-        "@types/parse5": {
-          "version": "2.2.34",
-          "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
-          "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
-          "dev": true,
-          "requires": {
-            "@types/node": "8.0.28"
-          }
-        },
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-          "dev": true
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "dev": true,
-          "requires": {
-            "@types/clone": "0.1.30",
-            "@types/node": "6.0.88",
-            "@types/parse5": "2.2.34",
-            "clone": "2.1.1",
-            "parse5": "2.2.3"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "6.0.88",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-              "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
-              "dev": true
-            }
-          }
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-          "dev": true
         }
       }
     },
     "postcss": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-      "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.3.1",
+        "js-base64": "2.3.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -8910,7 +8897,7 @@
       "integrity": "sha1-xjGwicbM5CK5oQ86lY0r7dOBkyQ=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "5.2.18"
       }
     },
     "postcss-media-query-parser": {
@@ -8928,7 +8915,7 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "log-symbols": "1.0.2",
-        "postcss": "5.2.17"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "chalk": {
@@ -8961,13 +8948,50 @@
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
       "dev": true
     },
+    "postcss-safe-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
+      "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
+      "dev": true,
+      "requires": {
+        "postcss": "6.0.13"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.2.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "postcss-scss": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-0.4.1.tgz",
       "integrity": "sha1-rXcbgfD3L19IRdCKpg+TVXZT1Uw=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "5.2.18"
       }
     },
     "postcss-selector-parser": {
@@ -9018,9 +9042,9 @@
       "dev": true
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -9055,13 +9079,13 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.1",
-        "ipaddr.js": "1.4.0"
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
       }
     },
     "pseudomap": {
@@ -9116,9 +9140,9 @@
       "optional": true
     },
     "qs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "randomatic": {
@@ -9169,35 +9193,21 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.1.tgz",
-      "integrity": "sha512-sxkd1uqaSj41SG5Vet9sNAxBMCMsmZ3LVhRkDlK8SbCpelTUB7JiMGHG70AZS6cFiCRgfNQhU2eLnTHYRFf7LA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-          "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
-          "dev": true
-        }
       }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -9313,9 +9323,9 @@
       "dev": true
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -9332,7 +9342,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "private": "0.1.7"
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -9350,7 +9360,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -9361,7 +9371,7 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1",
+        "rc": "1.2.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -9371,7 +9381,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1"
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -9437,41 +9447,35 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
+        "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.5",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
@@ -9507,6 +9511,12 @@
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
       }
+    },
+    "requirejs": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.5.tgz",
+      "integrity": "sha512-svnO+aNcR/an9Dpi44C7KSAy5fFGLtmPbaaCeQaklUz8BQhS64tWWIIlvEA5jrWICzlO/X9KSzSeXFnZdBu8nw==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -9550,9 +9560,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -9611,7 +9621,7 @@
         "async": "2.5.0",
         "https-proxy-agent": "1.0.0",
         "lodash": "4.17.4",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -9652,12 +9662,35 @@
         "yauzl": "2.8.0"
       },
       "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
+        },
         "async": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
           "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
           "dev": true,
           "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "caseless": {
           "version": "0.11.0",
@@ -9687,6 +9720,16 @@
           "dev": true,
           "optional": true
         },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
         "end-of-stream": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
@@ -9695,6 +9738,18 @@
           "optional": true,
           "requires": {
             "once": "1.4.0"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
           }
         },
         "har-validator": {
@@ -9717,6 +9772,37 @@
               "dev": true,
               "optional": true
             }
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "is-absolute": {
@@ -9807,9 +9893,19 @@
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
             "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
           }
         },
         "strip-ansi": {
@@ -9971,38 +10067,41 @@
       "dev": true
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.4"
+        "send": "0.16.1"
       },
       "dependencies": {
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        },
-        "send": {
-          "version": "0.15.4",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "debug": "2.6.8",
+            "ms": "2.0.0"
+          }
+        },
+        "send": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
             "depd": "1.1.1",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
-            "etag": "1.8.0",
-            "fresh": "0.5.0",
+            "etag": "1.8.1",
+            "fresh": "0.5.2",
             "http-errors": "1.6.2",
-            "mime": "1.3.4",
+            "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
@@ -10030,15 +10129,15 @@
       "dev": true
     },
     "setprototypeof": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shady-css-parser": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.0.8.tgz",
-      "integrity": "sha1-Ae7FprnsjkftvakbRN/lkSeeoNE=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA==",
       "dev": true
     },
     "shebang-command": {
@@ -10063,7 +10162,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "interpret": "1.0.3",
+        "interpret": "1.0.4",
         "rechoir": "0.6.2"
       }
     },
@@ -10092,9 +10191,9 @@
       }
     },
     "sinon-chai": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.13.0.tgz",
-      "integrity": "sha512-hRNu/TlYEp4Rw5IbzO8ykGoZMSG489PGUx1rvePpHGrtl20cXivRBgtr/EWYxIwL9EOO9+on04nd9k3tW8tVww==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
       "dev": true
     },
     "slash": {
@@ -10104,10 +10203,13 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0"
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -10116,12 +10218,12 @@
       "dev": true
     },
     "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "4.2.0"
       }
     },
     "socket.io": {
@@ -10342,12 +10444,23 @@
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "handle-thing": "1.2.5",
         "http-deceiver": "1.2.7",
         "safe-buffer": "5.1.1",
         "select-hose": "2.0.0",
         "spdy-transport": "2.0.20"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "spdy-transport": {
@@ -10356,19 +10469,30 @@
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "detect-node": "2.0.3",
         "hpack.js": "2.1.6",
         "obuf": "1.1.1",
         "readable-stream": "2.3.3",
         "safe-buffer": "5.1.1",
         "wbuf": "1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "specificity": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.1.tgz",
-      "integrity": "sha1-8bBoQkzjF64HR42V3jwhz4Xo1Wc=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
+      "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
       "dev": true
     },
     "split2": {
@@ -10436,14 +10560,6 @@
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "stack-trace": {
@@ -10643,7 +10759,7 @@
         "log-symbols": "1.0.2",
         "minimist": "1.2.0",
         "plur": "2.1.2",
-        "postcss": "5.2.17",
+        "postcss": "5.2.18",
         "postcss-reporter": "1.4.1",
         "postcss-selector-parser": "2.2.3",
         "read-file-stdin": "0.2.1",
@@ -10679,7 +10795,7 @@
             "chalk": "1.1.3",
             "lodash": "4.17.4",
             "log-symbols": "1.0.2",
-            "postcss": "5.2.17"
+            "postcss": "5.2.18"
           }
         },
         "strip-ansi": {
@@ -10694,16 +10810,16 @@
       }
     },
     "stylelint": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.1.1.tgz",
-      "integrity": "sha512-RtjUtqG2h3dP4CuMU1M++GRJGvKXWozmv5yhLoOLy7NWP2jJZOwLZSVwtcjXQsBJBfGuC33mooBOwNaCIhi2tQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.2.0.tgz",
+      "integrity": "sha512-57JWIz/1Uh9ehZMZyAqlFC0EDfQrMXCH8yqt8ZuJQQvV3LBKgAM/JYd+CWi1hC4eJtRODSPbIIBYKdGjkPZdMg==",
       "dev": true,
       "requires": {
-        "autoprefixer": "7.1.4",
+        "autoprefixer": "7.1.5",
         "balanced-match": "1.0.0",
-        "chalk": "2.1.0",
-        "cosmiconfig": "2.2.2",
-        "debug": "3.0.1",
+        "chalk": "2.2.0",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
         "execall": "1.0.0",
         "file-entry-cache": "2.0.0",
         "get-stdin": "5.0.1",
@@ -10712,62 +10828,66 @@
         "html-tags": "2.0.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "known-css-properties": "0.3.0",
+        "known-css-properties": "0.4.1",
         "lodash": "4.17.4",
-        "log-symbols": "2.0.0",
+        "log-symbols": "2.1.0",
         "mathml-tag-names": "2.0.1",
         "meow": "3.7.0",
         "micromatch": "2.3.11",
         "normalize-selector": "0.2.0",
         "pify": "3.0.0",
-        "postcss": "6.0.11",
-        "postcss-less": "1.1.0",
+        "postcss": "6.0.13",
+        "postcss-less": "1.1.1",
         "postcss-media-query-parser": "0.2.3",
         "postcss-reporter": "5.0.0",
         "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-safe-parser": "3.0.1",
         "postcss-scss": "1.0.2",
         "postcss-selector-parser": "2.2.3",
         "postcss-value-parser": "3.3.0",
-        "resolve-from": "3.0.0",
-        "specificity": "0.3.1",
+        "resolve-from": "4.0.0",
+        "specificity": "0.3.2",
         "string-width": "2.1.1",
         "style-search": "0.1.0",
         "sugarss": "1.0.0",
         "svg-tags": "1.0.0",
-        "table": "4.0.1"
+        "table": "4.0.2"
       },
       "dependencies": {
         "autoprefixer": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.4.tgz",
-          "integrity": "sha512-MB1XybOJqu1uAwpfSilAa1wSURNc4W310CFKvMj1fNaJBFxr1PGgz72vZaPr9ryKGqs2vYZ6jDyJ0aiGELjsoA==",
+          "version": "7.1.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.5.tgz",
+          "integrity": "sha512-sMN453qIm8Z+tunzYWW+Y490wWkICHhCYm/VohLjjl+N7ARSFuF5au7E6tr7oEbeeXj8mNjpSw2kxjJaO6YCOw==",
           "dev": true,
           "requires": {
-            "browserslist": "2.4.0",
-            "caniuse-lite": "1.0.30000727",
+            "browserslist": "2.5.1",
+            "caniuse-lite": "1.0.30000748",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
-            "postcss": "6.0.11",
+            "postcss": "6.0.13",
             "postcss-value-parser": "3.3.0"
           }
         },
         "browserslist": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
-          "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.5.1.tgz",
+          "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000727",
-            "electron-to-chromium": "1.3.21"
+            "caniuse-lite": "1.0.30000748",
+            "electron-to-chromium": "1.3.26"
           }
         },
-        "debug": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
-          "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+        "cosmiconfig": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+          "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.10.0",
+            "parse-json": "3.0.0",
+            "require-from-string": "2.0.1"
           }
         },
         "get-stdin": {
@@ -10798,18 +10918,27 @@
           }
         },
         "known-css-properties": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz",
-          "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.4.1.tgz",
+          "integrity": "sha512-n+ThoCKhyMFKkMfksdLMP5ndp+VzwDRzQdH6JlmZ2GTpUenYB2EeEKjOue2SErAAG/MmBSUISpwvawDhydWQdQ==",
           "dev": true
         },
         "log-symbols": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.0.0.tgz",
-          "integrity": "sha512-ValCSal2pRxRbet7O69a/1g5fZ2MLxf1YXIslNrdJF42ofY9zVf6MTqTwfhG+2x168xrbZATCgFQfXAwdNHv+w==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0"
+            "chalk": "2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
           }
         },
         "pify": {
@@ -10819,23 +10948,23 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.11",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.11.tgz",
-          "integrity": "sha512-DsnIzznNRQprsGTALpkC0xjDygo+QcOd+qVjP9+RjyzrPiyYOXBGOwoJ4rAiiE4lu6JggQ/jW4niY24WLxuncg==",
+          "version": "6.0.13",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
+          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
-            "source-map": "0.5.7",
-            "supports-color": "4.4.0"
+            "chalk": "2.2.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
           }
         },
         "postcss-less": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.0.tgz",
-          "integrity": "sha1-vcx2vmTEMk2HP7xc2foueZ5DBfo=",
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.1.tgz",
+          "integrity": "sha512-zl0EEqq8Urh37Ppdv9zzhpZpLHrgkxmt6e3O4ftRa7/b8Uq2LV+/KBVM8/KuzmHNu+mthhOArg1lxbfqQ3NUdg==",
           "dev": true,
           "requires": {
-            "postcss": "5.2.17"
+            "postcss": "5.2.18"
           },
           "dependencies": {
             "chalk": {
@@ -10866,16 +10995,22 @@
               "dev": true
             },
             "postcss": {
-              "version": "5.2.17",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-              "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+              "version": "5.2.18",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+              "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
               "dev": true,
               "requires": {
                 "chalk": "1.1.3",
-                "js-base64": "2.3.1",
+                "js-base64": "2.3.2",
                 "source-map": "0.5.7",
                 "supports-color": "3.2.3"
               }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
             },
             "supports-color": {
               "version": "3.2.3",
@@ -10894,10 +11029,10 @@
           "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
+            "chalk": "2.2.0",
             "lodash": "4.17.4",
-            "log-symbols": "2.0.0",
-            "postcss": "6.0.11"
+            "log-symbols": "2.1.0",
+            "postcss": "6.0.13"
           }
         },
         "postcss-scss": {
@@ -10906,13 +11041,25 @@
           "integrity": "sha1-/0XPM1S4ee6JpOtoaA9GrJuxT5Q=",
           "dev": true,
           "requires": {
-            "postcss": "6.0.11"
+            "postcss": "6.0.13"
           }
         },
+        "require-from-string": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
+        },
         "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "strip-ansi": {
@@ -10930,13 +11077,13 @@
           "integrity": "sha1-ZeUbOVhDL7cNVFGmi7M+MtDPHvc=",
           "dev": true,
           "requires": {
-            "postcss": "6.0.11"
+            "postcss": "6.0.13"
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -10956,7 +11103,7 @@
       "integrity": "sha1-rDQjdWMyfG/4l7ZHQr9q7BkK054=",
       "dev": true,
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "5.2.18"
       }
     },
     "supports-color": {
@@ -11036,51 +11183,17 @@
       }
     },
     "table": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
-      "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
+        "ajv": "5.2.3",
+        "ajv-keywords": "2.1.0",
+        "chalk": "2.2.0",
         "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
+        "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
       }
     },
     "table-layout": {
@@ -11098,9 +11211,9 @@
       }
     },
     "tar-fs": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.15.3.tgz",
-      "integrity": "sha1-7M+TXpQUk9gVECjmNuUc5MPKfyA=",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
       "dev": true,
       "requires": {
         "chownr": "1.0.1",
@@ -11250,9 +11363,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -11280,9 +11393,9 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
@@ -11360,19 +11473,27 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.14",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
-      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o=",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.0.tgz",
-      "integrity": "sha512-PGUXuTJ5AkrfPsyg0L9/LD+BWYm9feVngbWpW5bg7Q3B7hqDM3xz00tNby4yY0CqjrLTF6CP9wpb/aNITRuSXg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.4.tgz",
+      "integrity": "sha512-DcbkPg11Lw2lAWpwCmQDX+qoR4JiII6ypsQmF6tscZtlxGPFAmSRUGuMoVT3/0EHqypVik/TpkH4ITiMJeQqQA==",
       "dev": true,
       "requires": {
         "commander": "2.11.0",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "ultron": {
@@ -11483,9 +11604,9 @@
       "dev": true
     },
     "urijs": {
-      "version": "1.18.12",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.12.tgz",
-      "integrity": "sha512-WlvUkocbQ+GYhi8zkcbecbGYq7YLSd2I3InxAfqeh6mWvWalBE7bISDHcAL3J7STrWFfizuJ709srHD+RuABPQ==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz",
+      "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw==",
       "dev": true
     },
     "url-parse-lax": {
@@ -11527,9 +11648,9 @@
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -11570,9 +11691,9 @@
       "dev": true
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -11584,14 +11705,6 @@
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        }
       }
     },
     "vinyl": {
@@ -11763,7 +11876,7 @@
         "@types/express": "4.0.37",
         "@types/freeport": "1.0.21",
         "@types/launchpad": "0.6.0",
-        "@types/node": "6.0.88",
+        "@types/node": "6.0.90",
         "@types/which": "1.0.28",
         "chalk": "1.1.3",
         "cleankill": "1.0.3",
@@ -11775,9 +11888,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "6.0.88",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-          "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+          "version": "6.0.90",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.90.tgz",
+          "integrity": "sha512-tXoGRVdi7wZX7P1VWoV9Wfk0uYDOAHdEYXAttuWgSrN76Q32wQlSrMX0Rgyv3RTEaQY2ZLQrzYHVM2e8rfo8sA==",
           "dev": true,
           "optional": true
         },
@@ -11823,7 +11936,7 @@
         "chalk": "1.1.3",
         "cleankill": "1.0.3",
         "lodash": "3.10.1",
-        "request": "2.81.0",
+        "request": "2.83.0",
         "sauce-connect-launcher": "1.2.2",
         "temp": "0.8.3",
         "uuid": "2.0.3"
@@ -11863,9 +11976,9 @@
       }
     },
     "wd": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.4.0.tgz",
-      "integrity": "sha512-VHii2f+jck5fgEcTQYCR3z99B99tPz0HlLCGsNowI2qsI21xMnKwd9O3SnJQnEBq0Erx9FPFfiZno+OYtXDXyw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.4.1.tgz",
+      "integrity": "sha512-C0wWd2X4SWWcyx5qxaixiZE4Vb07sl0yDfWHPeml8lDHSbmI9erE9BmTHIqOGoDxGgJ3/hkFmODQ7ZLKiF8+8Q==",
       "dev": true,
       "requires": {
         "archiver": "1.3.0",
@@ -11878,6 +11991,12 @@
         "vargs": "0.1.0"
       },
       "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
         "async": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
@@ -11885,6 +12004,21 @@
           "dev": true,
           "requires": {
             "lodash": "4.16.2"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
           }
         },
         "caseless": {
@@ -11906,6 +12040,26 @@
             "supports-color": "2.0.0"
           }
         },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
         "har-validator": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
@@ -11916,6 +12070,35 @@
             "commander": "2.11.0",
             "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
           }
         },
         "lodash": {
@@ -11959,9 +12142,18 @@
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
             "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
           }
         },
         "strip-ansi": {
@@ -11988,41 +12180,41 @@
       }
     },
     "web-component-tester": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.1.5.tgz",
-      "integrity": "sha512-VvJG7l4wDSVMXChfCtCPzyqo0tMV56LtpX0S7XeJCQyCzLgSFdIP6n/md4UjWkvD9UCib1QR6WZd3JzHC4Nxpg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.3.0.tgz",
+      "integrity": "sha512-UZnbRBFh0/lAT3sZe0M9guWa9iHosKJP/HzaqDhVja0vxZlIiaVcHGVEQ1SqZbXCV3oOHKSBK2ff28oaknLCWg==",
       "dev": true,
       "requires": {
         "@polymer/sinonjs": "1.17.1",
         "@polymer/test-fixture": "0.0.3",
-        "@webcomponents/webcomponentsjs": "1.0.10",
+        "@webcomponents/webcomponentsjs": "1.0.17",
         "accessibility-developer-tools": "2.12.0",
         "async": "1.5.2",
-        "body-parser": "1.18.0",
+        "body-parser": "1.18.2",
         "chai": "3.5.0",
         "chalk": "1.1.3",
         "cleankill": "1.0.3",
-        "express": "4.15.4",
+        "express": "4.16.2",
         "findup-sync": "0.4.3",
         "glob": "7.1.2",
         "lodash": "3.10.1",
-        "mocha": "3.5.2",
+        "mocha": "3.5.3",
         "multer": "1.3.0",
         "nomnom": "1.8.1",
-        "polyserve": "0.20.0",
+        "polyserve": "0.23.0",
         "promisify-node": "0.4.0",
         "resolve": "1.4.0",
         "semver": "5.4.1",
         "send": "0.11.1",
         "server-destroy": "1.0.1",
         "sinon": "1.17.7",
-        "sinon-chai": "2.13.0",
+        "sinon-chai": "2.14.0",
         "socket.io": "1.7.4",
         "stacky": "1.3.1",
         "update-notifier": "1.0.3",
         "wct-local": "2.0.15",
         "wct-sauce": "2.0.0-pre.1",
-        "wd": "1.4.0"
+        "wd": "1.4.1"
       },
       "dependencies": {
         "async": {
@@ -12216,9 +12408,9 @@
       "dev": true
     },
     "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
       "dev": true,
       "requires": {
         "async": "1.0.0",
@@ -12392,7 +12584,7 @@
     "yargs": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
       "requires": {
         "camelcase": "4.1.0",
@@ -12527,7 +12719,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "diff": "2.2.3",
         "escape-string-regexp": "1.0.5",
         "globby": "4.1.0",
@@ -12566,6 +12758,15 @@
           "dev": true,
           "requires": {
             "restore-cursor": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "diff": {
@@ -12718,8 +12919,8 @@
         "cli-table": "0.3.1",
         "cross-spawn": "5.1.0",
         "dargs": "5.1.0",
-        "dateformat": "2.0.0",
-        "debug": "2.6.8",
+        "dateformat": "2.2.0",
+        "debug": "2.6.9",
         "detect-conflict": "1.0.1",
         "error": "7.0.2",
         "find-up": "2.1.0",
@@ -12735,7 +12936,7 @@
         "pretty-bytes": "4.0.2",
         "read-chunk": "2.1.0",
         "read-pkg-up": "2.0.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "run-async": "2.3.0",
         "shelljs": "0.7.8",
         "text-table": "0.2.0",
@@ -12764,6 +12965,15 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "find-up": {
@@ -12862,7 +13072,7 @@
       "dev": true,
       "requires": {
         "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.0",
+        "compress-commons": "1.2.2",
         "lodash": "4.17.4",
         "readable-stream": "2.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaadin-date-picker",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Polymer element providing a date selection field with scrollable month calendar",
   "main": "vaadin-date-picker.html",
   "repository": "vaadin/vaadin-date-picker",

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -48,7 +48,7 @@ This program is available under Apache License Version 2.0, available at https:/
         min-date="[[_minDate]]"
         max-date="[[_maxDate]]"
         role="dialog"
-		    show-week-numbers="[[showWeekNumbers]]"
+	show-week-numbers="[[showWeekNumbers]]"
         part="overlay">
       </vaadin-date-picker-overlay>
     </iron-dropdown>

--- a/vaadin-date-picker-light.html
+++ b/vaadin-date-picker-light.html
@@ -48,6 +48,7 @@ This program is available under Apache License Version 2.0, available at https:/
         min-date="[[_minDate]]"
         max-date="[[_maxDate]]"
         role="dialog"
+		    show-week-numbers="[[showWeekNumbers]]"
         part="overlay">
       </vaadin-date-picker-overlay>
     </iron-dropdown>


### PR DESCRIPTION
In the latest release of vaadin-date-picker, vaadin-date-picker-light does not support show-week-numbers.
Since vaadin-date-picker-light extends DatePickerMixin, this pull request should fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/453)
<!-- Reviewable:end -->
