### PR TITLE
Marking classes and properties @private, removing parameter from validate and CheckValidity

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -6,1947 +6,17 @@
       "description": "",
       "summary": "",
       "sourceRange": {
-        "file": "vaadin-date-picker-light.html",
+        "file": "vaadin-date-picker.html",
         "start": {
-          "line": 136,
+          "line": 267,
           "column": 6
         },
         "end": {
-          "line": 136,
+          "line": 267,
           "column": 42
         }
       },
       "elements": [
-        {
-          "description": "`<vaadin-date-picker>` is a date selection field which includes a scrollable\nmonth calendar view.\n```html\n<vaadin-date-picker label=\"Birthday\"></vaadin-date-picker>\n```\n```js\ndatePicker.value = '2016-03-02';\n```\nWhen the selected `value` is changed, a `value-changed` event is triggered.\n\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description | Theme for Element\n----------------|----------------|----------------\n`text-field` | Input element | vaadin-date-picker\n`clear-button` | Clear button | vaadin-date-picker\n`toggle-button` | Toggle button | vaadin-date-picker\n`overlay` | The overlay element | vaadin-date-picker\n`overlay` | The overlay element | vaadin-date-picker-light\n`overlay-header` | Fullscreen mode header | vaadin-date-picker-overlay\n`label` | Fullscreen mode value/label | vaadin-date-picker-overlay\n`clear-button` | Fullscreen mode clear button | vaadin-date-picker-overlay\n`toggle-button` | Fullscreen mode toggle button | vaadin-date-picker-overlay\n`years-toggle-button` | Fullscreen mode years scroller toggle | vaadin-date-picker-overlay\n`months` | Months scroller | vaadin-date-picker-overlay\n`years` | Years scroller | vaadin-date-picker-overlay\n`toolbar` | Footer bar with buttons | vaadin-date-picker-overlay\n`today-button` | Today button | vaadin-date-picker-overlay\n`cancel-button` | Cancel button | vaadin-date-picker-overlay\n`month` | Month calendar | vaadin-date-picker-overlay\n`year-number` | Year number | vaadin-date-picker-overlay\n`year-separator` | Year separator | vaadin-date-picker-overlay\n`month-header` | Month title | vaadin-month-calendar\n`weekdays` | Weekday container | vaadin-month-calendar\n`weekday` | Weekday element | vaadin-month-calendar\n`week-numbers` | Week numbers container | vaadin-month-calendar\n`week-number` | Week number element | vaadin-month-calendar\n`date` | Date element | vaadin-month-calendar\n\nIf you want to replace the default input field with a custom implementation, you should use the\n[`<vaadin-date-picker-light>`](#vaadin-date-picker-light) element.",
-          "summary": "",
-          "path": "vaadin-date-picker.html",
-          "properties": [
-            {
-              "name": "_selectedDate",
-              "type": "Date",
-              "description": "The current selected date.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 25,
-                  "column": 8
-                },
-                "end": {
-                  "line": 27,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_focusedDate",
-              "type": "Date",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 29,
-                  "column": 8
-                },
-                "end": {
-                  "line": 29,
-                  "column": 26
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "The value for this element.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 40,
-                  "column": 8
-                },
-                "end": {
-                  "line": 45,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "notify": true,
-                  "observer": "\"_valueChanged\""
-                }
-              },
-              "defaultValue": "\"\"",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "required",
-              "type": "boolean",
-              "description": "Set to true to mark the input as required.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 50,
-                  "column": 8
-                },
-                "end": {
-                  "line": 53,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "false",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "The name of this element.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 58,
-                  "column": 8
-                },
-                "end": {
-                  "line": 60,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "hasValue",
-              "type": "boolean",
-              "description": "Indicates whether this date picker has a value.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 65,
-                  "column": 8
-                },
-                "end": {
-                  "line": 69,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "initialPosition",
-              "type": "string",
-              "description": "Date which should be visible when there is no value selected.\n\nThe same date formats as for the `value` property are supported.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 76,
-                  "column": 8
-                },
-                "end": {
-                  "line": 76,
-                  "column": 31
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "label",
-              "type": "string",
-              "description": "The label for this element.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 81,
-                  "column": 8
-                },
-                "end": {
-                  "line": 81,
-                  "column": 21
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "opened",
-              "type": "boolean",
-              "description": "Set true to open the date selector overlay.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 86,
-                  "column": 8
-                },
-                "end": {
-                  "line": 90,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "notify": true
-                }
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "showWeekNumbers",
-              "type": "boolean",
-              "description": "Set true to display ISO-8601 week numbers in the calendar. Notice that\ndisplaying week numbers is only supported when `i18n.firstDayOfWeek`\nis 1 (Monday).",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 97,
-                  "column": 8
-                },
-                "end": {
-                  "line": 99,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_fullscreen",
-              "type": "?",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 101,
-                  "column": 8
-                },
-                "end": {
-                  "line": 104,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "observer": "\"_fullscreenChanged\""
-                }
-              },
-              "defaultValue": "false",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_fullscreenMediaQuery",
-              "type": "?",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 106,
-                  "column": 8
-                },
-                "end": {
-                  "line": 108,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "\"(max-width: 420px), (max-height: 420px)\"",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_touchPrevented",
-              "type": "Array",
-              "description": "'touch' to value 'auto' in order to prevent them from clipping the dropdown. iOS only.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 112,
-                  "column": 8
-                },
-                "end": {
-                  "line": 112,
-                  "column": 30
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "i18n",
-              "type": "Object",
-              "description": "The object used to localize this component.\nTo change the default localization, replace the entire\n_i18n_ object or just the property you want to modify.\n\nThe object has the following JSON structure and default values:\n\n            {\n              // An array with the full names of months starting\n              // with January.\n              monthNames: [\n                'January', 'February', 'March', 'April', 'May',\n                'June', 'July', 'August', 'September',\n                'October', 'November', 'December'\n              ],\n\n              // An array of weekday names starting with Sunday. Used\n              // in screen reader announcements.\n              weekdays: [\n                'Sunday', 'Monday', 'Tuesday', 'Wednesday',\n                'Thursday', 'Friday', 'Saturday'\n              ],\n\n              // An array of short weekday names starting with Sunday.\n              // Displayed in the calendar.\n              weekdaysShort: [\n                'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'\n              ],\n\n              // An integer indicating the first day of the week\n              // (0 = Sunday, 1 = Monday, etc.).\n              firstDayOfWeek: 0,\n\n              // Used in screen reader announcements along with week\n              // numbers, if they are displayed.\n              week: 'Week',\n\n              // Translation of the Calendar icon button title.\n              calendar: 'Calendar',\n\n              // Translation of the Clear icon button title.\n              clear: 'Clear',\n\n              // Translation of the Today shortcut button text.\n              today: 'Today',\n\n              // Translation of the Cancel button text.\n              cancel: 'Cancel',\n\n              // A function to format given `Date` object as\n              // date string.\n              formatDate: d => {\n                // returns a string representation of the given\n                // Date object in 'MM/DD/YYYY' -format\n              },\n\n              // A function to parse the given text to a `Date`\n              // object. Must properly parse (at least) text\n              // formatted by `formatDate`.\n              // Setting the property to null will disable\n              // keyboard input feature.\n              parseDate: text => {\n                // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to\n                // a Date object\n              }\n\n              // A function to format given `monthName` and\n              // `fullYear` integer as calendar title string.\n              formatTitle: (monthName, fullYear) => {\n                return monthName + ' ' + fullYear;\n              }\n            }",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 190,
-                  "column": 8
-                },
-                "end": {
-                  "line": 246,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "min",
-              "type": "string",
-              "description": "The earliest date that can be selected. All earlier dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 257,
-                  "column": 8
-                },
-                "end": {
-                  "line": 260,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "observer": "\"_minChanged\""
-                }
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "max",
-              "type": "string",
-              "description": "The latest date that can be selected. All later dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 271,
-                  "column": 8
-                },
-                "end": {
-                  "line": 274,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "observer": "\"_maxChanged\""
-                }
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_minDate",
-              "type": "Date",
-              "description": "The earliest date that can be selected. All earlier dates will be disabled.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 279,
-                  "column": 8
-                },
-                "end": {
-                  "line": 283,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "\"\"",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_maxDate",
-              "type": "Date",
-              "description": "The latest date that can be selected. All later dates will be disabled.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 288,
-                  "column": 8
-                },
-                "end": {
-                  "line": 291,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "\"\"",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_noInput",
-              "type": "boolean",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 293,
-                  "column": 8
-                },
-                "end": {
-                  "line": 296,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_ios",
-              "type": "boolean",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 298,
-                  "column": 8
-                },
-                "end": {
-                  "line": 301,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_ignoreAnnounce",
-              "type": "?",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 303,
-                  "column": 8
-                },
-                "end": {
-                  "line": 305,
-                  "column": 9
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "true",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_focusOverlayOnOpen",
-              "type": "boolean",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 307,
-                  "column": 8
-                },
-                "end": {
-                  "line": 307,
-                  "column": 36
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_documentPointerEvents",
-              "type": "string",
-              "description": "When datepicker is opened, we're setting body pointer-events to none\nto make the datepicker behave in \"modal\" way. This variable keeps the\nprevious state of body pointer-events to restore it when datepicker is\nclosed.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 315,
-                  "column": 8
-                },
-                "end": {
-                  "line": 315,
-                  "column": 38
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "disabled",
-              "type": "boolean",
-              "description": "Set to true to disable this element.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 181,
-                  "column": 12
-                },
-                "end": {
-                  "line": 185,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "false"
-            },
-            {
-              "name": "errorMessage",
-              "type": "string",
-              "description": "The error message to display when the input is invalid.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 190,
-                  "column": 12
-                },
-                "end": {
-                  "line": 190,
-                  "column": 32
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "placeholder",
-              "type": "string",
-              "description": "A placeholder string in addition to the label. If this is set, the label will always float.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 195,
-                  "column": 12
-                },
-                "end": {
-                  "line": 195,
-                  "column": 31
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "readonly",
-              "type": "boolean",
-              "description": "Set to true to make this element read-only.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 200,
-                  "column": 12
-                },
-                "end": {
-                  "line": 204,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "false"
-            },
-            {
-              "name": "invalid",
-              "type": "boolean",
-              "description": "This property is set to true when the control value invalid.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 209,
-                  "column": 12
-                },
-                "end": {
-                  "line": 214,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "notify": true
-                }
-              },
-              "defaultValue": "false"
-            },
-            {
-              "name": "_userInputValue",
-              "type": "string",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 216,
-                  "column": 12
-                },
-                "end": {
-                  "line": 216,
-                  "column": 35
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            }
-          ],
-          "methods": [
-            {
-              "name": "ready",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 226,
-                  "column": 8
-                },
-                "end": {
-                  "line": 231,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "open",
-              "description": "Opens the dropdown.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 343,
-                  "column": 4
-                },
-                "end": {
-                  "line": 348,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_close",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 350,
-                  "column": 4
-                },
-                "end": {
-                  "line": 356,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "close",
-              "description": "Closes the dropdown.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 361,
-                  "column": 4
-                },
-                "end": {
-                  "line": 363,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_parseDate",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 379,
-                  "column": 4
-                },
-                "end": {
-                  "line": 391,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "str"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_isNoInput",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 393,
-                  "column": 4
-                },
-                "end": {
-                  "line": 395,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_formatISO",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 397,
-                  "column": 4
-                },
-                "end": {
-                  "line": 401,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "date"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_selectedDateChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 403,
-                  "column": 4
-                },
-                "end": {
-                  "line": 410,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "selectedDate"
-                },
-                {
-                  "name": "formatDate"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_focusedDateChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 412,
-                  "column": 4
-                },
-                "end": {
-                  "line": 419,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "focusedDate"
-                },
-                {
-                  "name": "formatDate"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_hasValue",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 421,
-                  "column": 4
-                },
-                "end": {
-                  "line": 423,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_handleDateChange",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 425,
-                  "column": 4
-                },
-                "end": {
-                  "line": 439,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property"
-                },
-                {
-                  "name": "value"
-                },
-                {
-                  "name": "oldValue"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_valueChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 441,
-                  "column": 4
-                },
-                "end": {
-                  "line": 443,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                },
-                {
-                  "name": "oldValue"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_minChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 445,
-                  "column": 4
-                },
-                "end": {
-                  "line": 447,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                },
-                {
-                  "name": "oldValue"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_maxChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 449,
-                  "column": 4
-                },
-                "end": {
-                  "line": 451,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                },
-                {
-                  "name": "oldValue"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_updateAlignmentAndPosition",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 453,
-                  "column": 4
-                },
-                "end": {
-                  "line": 475,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_fullscreenChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 477,
-                  "column": 4
-                },
-                "end": {
-                  "line": 481,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_onOverlayOpened",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 483,
-                  "column": 4
-                },
-                "end": {
-                  "line": 526,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_preventWebkitOverflowScrollingTouch",
-              "description": "ancestor container with -webkit-overflow-scrolling: touch;",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 530,
-                  "column": 4
-                },
-                "end": {
-                  "line": 544,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "element"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_onOverlayClosed",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 546,
-                  "column": 4
-                },
-                "end": {
-                  "line": 584,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "detached",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 586,
-                  "column": 4
-                },
-                "end": {
-                  "line": 588,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "validate",
-              "description": "Returns true if `value` is valid, and sets the `invalid` flag appropriatelly.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 595,
-                  "column": 4
-                },
-                "end": {
-                  "line": 598,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if the value is valid and sets the `invalid` flag appropriatelly"
-              },
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "checkValidity",
-              "description": "Returns true if the current input value satisfies all constraints (if any)\n\nOverride the `checkValidity` method for custom validations.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 605,
-                  "column": 4
-                },
-                "end": {
-                  "line": 622,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_onScroll",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 624,
-                  "column": 4
-                },
-                "end": {
-                  "line": 628,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_preventCancelOnComponentAccess",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 630,
-                  "column": 4
-                },
-                "end": {
-                  "line": 635,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_focus",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 637,
-                  "column": 4
-                },
-                "end": {
-                  "line": 643,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_focusAndSelect",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 645,
-                  "column": 4
-                },
-                "end": {
-                  "line": 648,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_setSelectionRange",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 650,
-                  "column": 4
-                },
-                "end": {
-                  "line": 654,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "a"
-                },
-                {
-                  "name": "b"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_preventDefault",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 656,
-                  "column": 4
-                },
-                "end": {
-                  "line": 658,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_eventKey",
-              "description": "Keyboard Navigation",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 663,
-                  "column": 4
-                },
-                "end": {
-                  "line": 672,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_isValidDate",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 674,
-                  "column": 4
-                },
-                "end": {
-                  "line": 676,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "d"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_onKeydown",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 678,
-                  "column": 4
-                },
-                "end": {
-                  "line": 731,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_validateInput",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 733,
-                  "column": 4
-                },
-                "end": {
-                  "line": 737,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "date"
-                },
-                {
-                  "name": "min"
-                },
-                {
-                  "name": "max"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_onUserInput",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 739,
-                  "column": 4
-                },
-                "end": {
-                  "line": 750,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_userInputValueChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 752,
-                  "column": 4
-                },
-                "end": {
-                  "line": 761,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_announceFocusedDate",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 763,
-                  "column": 4
-                },
-                "end": {
-                  "line": 767,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "_focusedDate"
-                },
-                {
-                  "name": "opened"
-                },
-                {
-                  "name": "_ignoreAnnounce"
-                }
-              ],
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "_addEventListenerToNode",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/gesture-event-listeners.html",
-                "start": {
-                  "line": 41,
-                  "column": 6
-                },
-                "end": {
-                  "line": 45,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node"
-                },
-                {
-                  "name": "eventName"
-                },
-                {
-                  "name": "handler"
-                }
-              ],
-              "inheritedFrom": "Polymer.GestureEventListeners"
-            },
-            {
-              "name": "_removeEventListenerFromNode",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/gesture-event-listeners.html",
-                "start": {
-                  "line": 47,
-                  "column": 6
-                },
-                "end": {
-                  "line": 51,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node"
-                },
-                {
-                  "name": "eventName"
-                },
-                {
-                  "name": "handler"
-                }
-              ],
-              "inheritedFrom": "Polymer.GestureEventListeners"
-            },
-            {
-              "name": "_clear",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 233,
-                  "column": 8
-                },
-                "end": {
-                  "line": 237,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ]
-            },
-            {
-              "name": "_toggle",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 239,
-                  "column": 8
-                },
-                "end": {
-                  "line": 242,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "e"
-                }
-              ]
-            },
-            {
-              "name": "_input",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 244,
-                  "column": 8
-                },
-                "end": {
-                  "line": 246,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_getAriaExpanded",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 256,
-                  "column": 8
-                },
-                "end": {
-                  "line": 258,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "opened"
-                }
-              ]
-            }
-          ],
-          "staticMethods": [
-            {
-              "name": "includeStyle",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
-                "start": {
-                  "line": 38,
-                  "column": 4
-                },
-                "end": {
-                  "line": 42,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "moduleName"
-                }
-              ],
-              "inheritedFrom": "Vaadin.ThemableMixin"
-            }
-          ],
-          "demos": [
-            {
-              "url": "demo/index.html",
-              "description": ""
-            }
-          ],
-          "metadata": {},
-          "sourceRange": {
-            "start": {
-              "line": 170,
-              "column": 6
-            },
-            "end": {
-              "line": 259,
-              "column": 7
-            }
-          },
-          "privacy": "public",
-          "superclass": "HTMLElement",
-          "name": "Vaadin.DatePickerElement",
-          "attributes": [
-            {
-              "name": "value",
-              "description": "The value for this element.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 40,
-                  "column": 8
-                },
-                "end": {
-                  "line": 45,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "string",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "required",
-              "description": "Set to true to mark the input as required.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 50,
-                  "column": 8
-                },
-                "end": {
-                  "line": 53,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "boolean",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "name",
-              "description": "The name of this element.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 58,
-                  "column": 8
-                },
-                "end": {
-                  "line": 60,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "string",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "has-value",
-              "description": "Indicates whether this date picker has a value.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 65,
-                  "column": 8
-                },
-                "end": {
-                  "line": 69,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "boolean",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "initial-position",
-              "description": "Date which should be visible when there is no value selected.\n\nThe same date formats as for the `value` property are supported.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 76,
-                  "column": 8
-                },
-                "end": {
-                  "line": 76,
-                  "column": 31
-                }
-              },
-              "metadata": {},
-              "type": "string",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "label",
-              "description": "The label for this element.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 81,
-                  "column": 8
-                },
-                "end": {
-                  "line": 81,
-                  "column": 21
-                }
-              },
-              "metadata": {},
-              "type": "string",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "opened",
-              "description": "Set true to open the date selector overlay.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 86,
-                  "column": 8
-                },
-                "end": {
-                  "line": 90,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "boolean",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "show-week-numbers",
-              "description": "Set true to display ISO-8601 week numbers in the calendar. Notice that\ndisplaying week numbers is only supported when `i18n.firstDayOfWeek`\nis 1 (Monday).",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 97,
-                  "column": 8
-                },
-                "end": {
-                  "line": 99,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "boolean",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "i18n",
-              "description": "The object used to localize this component.\nTo change the default localization, replace the entire\n_i18n_ object or just the property you want to modify.\n\nThe object has the following JSON structure and default values:\n\n            {\n              // An array with the full names of months starting\n              // with January.\n              monthNames: [\n                'January', 'February', 'March', 'April', 'May',\n                'June', 'July', 'August', 'September',\n                'October', 'November', 'December'\n              ],\n\n              // An array of weekday names starting with Sunday. Used\n              // in screen reader announcements.\n              weekdays: [\n                'Sunday', 'Monday', 'Tuesday', 'Wednesday',\n                'Thursday', 'Friday', 'Saturday'\n              ],\n\n              // An array of short weekday names starting with Sunday.\n              // Displayed in the calendar.\n              weekdaysShort: [\n                'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'\n              ],\n\n              // An integer indicating the first day of the week\n              // (0 = Sunday, 1 = Monday, etc.).\n              firstDayOfWeek: 0,\n\n              // Used in screen reader announcements along with week\n              // numbers, if they are displayed.\n              week: 'Week',\n\n              // Translation of the Calendar icon button title.\n              calendar: 'Calendar',\n\n              // Translation of the Clear icon button title.\n              clear: 'Clear',\n\n              // Translation of the Today shortcut button text.\n              today: 'Today',\n\n              // Translation of the Cancel button text.\n              cancel: 'Cancel',\n\n              // A function to format given `Date` object as\n              // date string.\n              formatDate: d => {\n                // returns a string representation of the given\n                // Date object in 'MM/DD/YYYY' -format\n              },\n\n              // A function to parse the given text to a `Date`\n              // object. Must properly parse (at least) text\n              // formatted by `formatDate`.\n              // Setting the property to null will disable\n              // keyboard input feature.\n              parseDate: text => {\n                // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to\n                // a Date object\n              }\n\n              // A function to format given `monthName` and\n              // `fullYear` integer as calendar title string.\n              formatTitle: (monthName, fullYear) => {\n                return monthName + ' ' + fullYear;\n              }\n            }",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 190,
-                  "column": 8
-                },
-                "end": {
-                  "line": 246,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "Object",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "min",
-              "description": "The earliest date that can be selected. All earlier dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 257,
-                  "column": 8
-                },
-                "end": {
-                  "line": 260,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "string",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "max",
-              "description": "The latest date that can be selected. All later dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 271,
-                  "column": 8
-                },
-                "end": {
-                  "line": 274,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "string",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
-              "name": "disabled",
-              "description": "Set to true to disable this element.",
-              "sourceRange": {
-                "start": {
-                  "line": 181,
-                  "column": 12
-                },
-                "end": {
-                  "line": 185,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            },
-            {
-              "name": "error-message",
-              "description": "The error message to display when the input is invalid.",
-              "sourceRange": {
-                "start": {
-                  "line": 190,
-                  "column": 12
-                },
-                "end": {
-                  "line": 190,
-                  "column": 32
-                }
-              },
-              "metadata": {},
-              "type": "string"
-            },
-            {
-              "name": "placeholder",
-              "description": "A placeholder string in addition to the label. If this is set, the label will always float.",
-              "sourceRange": {
-                "start": {
-                  "line": 195,
-                  "column": 12
-                },
-                "end": {
-                  "line": 195,
-                  "column": 31
-                }
-              },
-              "metadata": {},
-              "type": "string"
-            },
-            {
-              "name": "readonly",
-              "description": "Set to true to make this element read-only.",
-              "sourceRange": {
-                "start": {
-                  "line": 200,
-                  "column": 12
-                },
-                "end": {
-                  "line": 204,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            },
-            {
-              "name": "invalid",
-              "description": "This property is set to true when the control value invalid.",
-              "sourceRange": {
-                "start": {
-                  "line": 209,
-                  "column": 12
-                },
-                "end": {
-                  "line": 214,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            }
-          ],
-          "events": [
-            {
-              "type": "CustomEvent",
-              "name": "invalid-changed",
-              "description": "Fired when the `invalid` property changes.",
-              "metadata": {}
-            }
-          ],
-          "styling": {
-            "cssVariables": [],
-            "selectors": []
-          },
-          "slots": [
-            {
-              "description": "",
-              "name": "prefix",
-              "range": {
-                "file": "vaadin-date-picker.html",
-                "start": {
-                  "line": 76,
-                  "column": 6
-                },
-                "end": {
-                  "line": 76,
-                  "column": 47
-                }
-              }
-            }
-          ],
-          "tagname": "vaadin-date-picker",
-          "mixins": [
-            "Vaadin.ThemableMixin",
-            "Vaadin.DatePickerMixin",
-            "Polymer.GestureEventListeners"
-          ]
-        },
         {
           "description": "`<vaadin-date-picker-light>` is a customizable version of the `<vaadin-date-picker>` providing\nonly the scrollable month calendar view and leaving the input field definition to the user.\n\nTo create a custom input field, you need to add a child element which has a two-way\ndata-bindable property representing the input value. The property name is expected\nto be `bindValue` by default. See the example below for a simplest possible example\nusing an `<input>` element extended with `iron-input`.\n\n```html\n<vaadin-date-picker-light>\n<iron-input>\n<input/>\n</iron-input>\n</vaadin-date-picker-light>\n```\n\nIf you are using other custom input fields like `<paper-input>`, you\nneed to define the name of value property using the `attrForValue` property.\n\n```html\n<vaadin-date-picker-light attr-for-value=\"value\">\n<paper-input label=\"Birthday\">\n</paper-input>\n</vaadin-date-picker-light>\n```",
           "summary": "",
@@ -2066,15 +136,15 @@
               "name": "hasValue",
               "type": "boolean",
               "description": "Indicates whether this date picker has a value.",
-              "privacy": "public",
+              "privacy": "private",
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 65,
+                  "line": 66,
                   "column": 8
                 },
                 "end": {
-                  "line": 69,
+                  "line": 70,
                   "column": 9
                 }
               },
@@ -2093,11 +163,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 76,
+                  "line": 77,
                   "column": 8
                 },
                 "end": {
-                  "line": 76,
+                  "line": 77,
                   "column": 31
                 }
               },
@@ -2114,11 +184,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 81,
+                  "line": 82,
                   "column": 8
                 },
                 "end": {
-                  "line": 81,
+                  "line": 82,
                   "column": 21
                 }
               },
@@ -2135,11 +205,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 86,
+                  "line": 87,
                   "column": 8
                 },
                 "end": {
-                  "line": 90,
+                  "line": 91,
                   "column": 9
                 }
               },
@@ -2158,11 +228,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 97,
+                  "line": 98,
                   "column": 8
                 },
                 "end": {
-                  "line": 99,
+                  "line": 100,
                   "column": 9
                 }
               },
@@ -2179,11 +249,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 101,
+                  "line": 102,
                   "column": 8
                 },
                 "end": {
-                  "line": 104,
+                  "line": 105,
                   "column": 9
                 }
               },
@@ -2203,11 +273,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 106,
+                  "line": 107,
                   "column": 8
                 },
                 "end": {
-                  "line": 108,
+                  "line": 109,
                   "column": 9
                 }
               },
@@ -2225,11 +295,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 112,
+                  "line": 113,
                   "column": 8
                 },
                 "end": {
-                  "line": 112,
+                  "line": 113,
                   "column": 30
                 }
               },
@@ -2246,11 +316,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 190,
+                  "line": 191,
                   "column": 8
                 },
                 "end": {
-                  "line": 246,
+                  "line": 244,
                   "column": 9
                 }
               },
@@ -2267,11 +337,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 257,
+                  "line": 255,
                   "column": 8
                 },
                 "end": {
-                  "line": 260,
+                  "line": 258,
                   "column": 9
                 }
               },
@@ -2290,11 +360,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 271,
+                  "line": 269,
                   "column": 8
                 },
                 "end": {
-                  "line": 274,
+                  "line": 272,
                   "column": 9
                 }
               },
@@ -2313,11 +383,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 279,
+                  "line": 277,
                   "column": 8
                 },
                 "end": {
-                  "line": 283,
+                  "line": 281,
                   "column": 9
                 }
               },
@@ -2335,11 +405,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 288,
+                  "line": 286,
                   "column": 8
                 },
                 "end": {
-                  "line": 291,
+                  "line": 289,
                   "column": 9
                 }
               },
@@ -2357,11 +427,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 293,
+                  "line": 291,
                   "column": 8
                 },
                 "end": {
-                  "line": 296,
+                  "line": 294,
                   "column": 9
                 }
               },
@@ -2380,11 +450,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 298,
+                  "line": 296,
                   "column": 8
                 },
                 "end": {
-                  "line": 301,
+                  "line": 299,
                   "column": 9
                 }
               },
@@ -2401,11 +471,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 303,
+                  "line": 301,
                   "column": 8
                 },
                 "end": {
-                  "line": 305,
+                  "line": 303,
                   "column": 9
                 }
               },
@@ -2423,11 +493,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 307,
+                  "line": 305,
                   "column": 8
                 },
                 "end": {
-                  "line": 307,
+                  "line": 305,
                   "column": 36
                 }
               },
@@ -2444,11 +514,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 315,
+                  "line": 313,
                   "column": 8
                 },
                 "end": {
-                  "line": 315,
+                  "line": 313,
                   "column": 38
                 }
               },
@@ -2464,11 +534,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 107,
+                  "line": 103,
                   "column": 12
                 },
                 "end": {
-                  "line": 110,
+                  "line": 106,
                   "column": 13
                 }
               },
@@ -2486,11 +556,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 328,
+                  "line": 326,
                   "column": 4
                 },
                 "end": {
-                  "line": 338,
+                  "line": 336,
                   "column": 5
                 }
               },
@@ -2505,11 +575,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 343,
+                  "line": 341,
                   "column": 4
                 },
                 "end": {
-                  "line": 348,
+                  "line": 346,
                   "column": 5
                 }
               },
@@ -2524,11 +594,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 350,
+                  "line": 348,
                   "column": 4
                 },
                 "end": {
-                  "line": 356,
+                  "line": 354,
                   "column": 5
                 }
               },
@@ -2547,11 +617,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 361,
+                  "line": 359,
                   "column": 4
                 },
                 "end": {
-                  "line": 363,
+                  "line": 361,
                   "column": 5
                 }
               },
@@ -2566,11 +636,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 379,
+                  "line": 377,
                   "column": 4
                 },
                 "end": {
-                  "line": 391,
+                  "line": 389,
                   "column": 5
                 }
               },
@@ -2589,11 +659,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 393,
+                  "line": 391,
                   "column": 4
                 },
                 "end": {
-                  "line": 395,
+                  "line": 393,
                   "column": 5
                 }
               },
@@ -2608,11 +678,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 397,
+                  "line": 395,
                   "column": 4
                 },
                 "end": {
-                  "line": 401,
+                  "line": 399,
                   "column": 5
                 }
               },
@@ -2631,11 +701,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 403,
+                  "line": 401,
                   "column": 4
                 },
                 "end": {
-                  "line": 410,
+                  "line": 408,
                   "column": 5
                 }
               },
@@ -2657,11 +727,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 412,
+                  "line": 410,
                   "column": 4
                 },
                 "end": {
-                  "line": 419,
+                  "line": 417,
                   "column": 5
                 }
               },
@@ -2683,11 +753,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 421,
+                  "line": 419,
                   "column": 4
                 },
                 "end": {
-                  "line": 423,
+                  "line": 421,
                   "column": 5
                 }
               },
@@ -2706,11 +776,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 425,
+                  "line": 423,
                   "column": 4
                 },
                 "end": {
-                  "line": 439,
+                  "line": 437,
                   "column": 5
                 }
               },
@@ -2735,11 +805,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 441,
+                  "line": 439,
                   "column": 4
                 },
                 "end": {
-                  "line": 443,
+                  "line": 441,
                   "column": 5
                 }
               },
@@ -2761,11 +831,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 445,
+                  "line": 443,
                   "column": 4
                 },
                 "end": {
-                  "line": 447,
+                  "line": 445,
                   "column": 5
                 }
               },
@@ -2787,11 +857,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 449,
+                  "line": 447,
                   "column": 4
                 },
                 "end": {
-                  "line": 451,
+                  "line": 449,
                   "column": 5
                 }
               },
@@ -2813,11 +883,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 453,
+                  "line": 451,
                   "column": 4
                 },
                 "end": {
-                  "line": 475,
+                  "line": 473,
                   "column": 5
                 }
               },
@@ -2832,11 +902,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 477,
+                  "line": 475,
                   "column": 4
                 },
                 "end": {
-                  "line": 481,
+                  "line": 479,
                   "column": 5
                 }
               },
@@ -2851,11 +921,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 483,
+                  "line": 481,
                   "column": 4
                 },
                 "end": {
-                  "line": 526,
+                  "line": 529,
                   "column": 5
                 }
               },
@@ -2870,11 +940,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 530,
+                  "line": 533,
                   "column": 4
                 },
                 "end": {
-                  "line": 544,
+                  "line": 547,
                   "column": 5
                 }
               },
@@ -2893,11 +963,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 546,
+                  "line": 549,
                   "column": 4
                 },
                 "end": {
-                  "line": 584,
+                  "line": 587,
                   "column": 5
                 }
               },
@@ -2912,11 +982,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 586,
+                  "line": 589,
                   "column": 4
                 },
                 "end": {
-                  "line": 588,
+                  "line": 591,
                   "column": 5
                 }
               },
@@ -2931,18 +1001,20 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 595,
+                  "line": 599,
                   "column": 4
                 },
                 "end": {
-                  "line": 598,
+                  "line": 602,
                   "column": 5
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Value to validate. Optional, defaults to user's input value."
                 }
               ],
               "return": {
@@ -2958,20 +1030,26 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 605,
+                  "line": 612,
                   "column": 4
                 },
                 "end": {
-                  "line": 622,
+                  "line": 629,
                   "column": 5
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Value to validate. Optional, defaults to the selected date."
                 }
               ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the value is valid"
+              },
               "inheritedFrom": "Vaadin.DatePickerMixin"
             },
             {
@@ -2981,11 +1059,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 624,
+                  "line": 631,
                   "column": 4
                 },
                 "end": {
-                  "line": 628,
+                  "line": 635,
                   "column": 5
                 }
               },
@@ -3004,11 +1082,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 630,
+                  "line": 637,
                   "column": 4
                 },
                 "end": {
-                  "line": 635,
+                  "line": 642,
                   "column": 5
                 }
               },
@@ -3027,11 +1105,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 637,
+                  "line": 644,
                   "column": 4
                 },
                 "end": {
-                  "line": 643,
+                  "line": 650,
                   "column": 5
                 }
               },
@@ -3046,11 +1124,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 645,
+                  "line": 652,
                   "column": 4
                 },
                 "end": {
-                  "line": 648,
+                  "line": 655,
                   "column": 5
                 }
               },
@@ -3065,11 +1143,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 650,
+                  "line": 657,
                   "column": 4
                 },
                 "end": {
-                  "line": 654,
+                  "line": 661,
                   "column": 5
                 }
               },
@@ -3091,11 +1169,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 656,
+                  "line": 663,
                   "column": 4
                 },
                 "end": {
-                  "line": 658,
+                  "line": 665,
                   "column": 5
                 }
               },
@@ -3114,11 +1192,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 663,
+                  "line": 670,
                   "column": 4
                 },
                 "end": {
-                  "line": 672,
+                  "line": 679,
                   "column": 5
                 }
               },
@@ -3137,11 +1215,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 674,
+                  "line": 681,
                   "column": 4
                 },
                 "end": {
-                  "line": 676,
+                  "line": 683,
                   "column": 5
                 }
               },
@@ -3160,11 +1238,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 678,
+                  "line": 685,
                   "column": 4
                 },
                 "end": {
-                  "line": 731,
+                  "line": 738,
                   "column": 5
                 }
               },
@@ -3183,11 +1261,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 733,
+                  "line": 740,
                   "column": 4
                 },
                 "end": {
-                  "line": 737,
+                  "line": 744,
                   "column": 5
                 }
               },
@@ -3212,11 +1290,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 739,
+                  "line": 746,
                   "column": 4
                 },
                 "end": {
-                  "line": 750,
+                  "line": 757,
                   "column": 5
                 }
               },
@@ -3235,11 +1313,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 752,
+                  "line": 759,
                   "column": 4
                 },
                 "end": {
-                  "line": 761,
+                  "line": 768,
                   "column": 5
                 }
               },
@@ -3258,11 +1336,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 763,
+                  "line": 770,
                   "column": 4
                 },
                 "end": {
-                  "line": 767,
+                  "line": 774,
                   "column": 5
                 }
               },
@@ -3286,11 +1364,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 114,
+                  "line": 110,
                   "column": 8
                 },
                 "end": {
-                  "line": 118,
+                  "line": 114,
                   "column": 9
                 }
               },
@@ -3303,11 +1381,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 6
             },
             "end": {
-              "line": 129,
+              "line": 125,
               "column": 7
             }
           },
@@ -3370,34 +1448,16 @@
               "inheritedFrom": "Vaadin.DatePickerMixin"
             },
             {
-              "name": "has-value",
-              "description": "Indicates whether this date picker has a value.",
-              "sourceRange": {
-                "file": "vaadin-date-picker-mixin.html",
-                "start": {
-                  "line": 65,
-                  "column": 8
-                },
-                "end": {
-                  "line": 69,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "boolean",
-              "inheritedFrom": "Vaadin.DatePickerMixin"
-            },
-            {
               "name": "initial-position",
               "description": "Date which should be visible when there is no value selected.\n\nThe same date formats as for the `value` property are supported.",
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 76,
+                  "line": 77,
                   "column": 8
                 },
                 "end": {
-                  "line": 76,
+                  "line": 77,
                   "column": 31
                 }
               },
@@ -3411,11 +1471,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 81,
+                  "line": 82,
                   "column": 8
                 },
                 "end": {
-                  "line": 81,
+                  "line": 82,
                   "column": 21
                 }
               },
@@ -3429,11 +1489,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 86,
+                  "line": 87,
                   "column": 8
                 },
                 "end": {
-                  "line": 90,
+                  "line": 91,
                   "column": 9
                 }
               },
@@ -3447,11 +1507,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 97,
+                  "line": 98,
                   "column": 8
                 },
                 "end": {
-                  "line": 99,
+                  "line": 100,
                   "column": 9
                 }
               },
@@ -3465,11 +1525,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 190,
+                  "line": 191,
                   "column": 8
                 },
                 "end": {
-                  "line": 246,
+                  "line": 244,
                   "column": 9
                 }
               },
@@ -3483,11 +1543,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 257,
+                  "line": 255,
                   "column": 8
                 },
                 "end": {
-                  "line": 260,
+                  "line": 258,
                   "column": 9
                 }
               },
@@ -3501,11 +1561,11 @@
               "sourceRange": {
                 "file": "vaadin-date-picker-mixin.html",
                 "start": {
-                  "line": 271,
+                  "line": 269,
                   "column": 8
                 },
                 "end": {
-                  "line": 274,
+                  "line": 272,
                   "column": 9
                 }
               },
@@ -3518,11 +1578,11 @@
               "description": "Name of the two-way data-bindable property representing the\nvalue of the custom input field.",
               "sourceRange": {
                 "start": {
-                  "line": 107,
+                  "line": 103,
                   "column": 12
                 },
                 "end": {
-                  "line": 110,
+                  "line": 106,
                   "column": 13
                 }
               },
@@ -3555,6 +1615,1926 @@
           "tagname": "vaadin-date-picker-light",
           "mixins": [
             "Vaadin.DatePickerMixin"
+          ]
+        },
+        {
+          "description": "`<vaadin-date-picker>` is a date selection field which includes a scrollable\nmonth calendar view.\n```html\n<vaadin-date-picker label=\"Birthday\"></vaadin-date-picker>\n```\n```js\ndatePicker.value = '2016-03-02';\n```\nWhen the selected `value` is changed, a `value-changed` event is triggered.\n\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description | Theme for Element\n----------------|----------------|----------------\n`text-field` | Input element | vaadin-date-picker\n`clear-button` | Clear button | vaadin-date-picker\n`toggle-button` | Toggle button | vaadin-date-picker\n`overlay` | The overlay element | vaadin-date-picker\n`overlay` | The overlay element | vaadin-date-picker-light\n`overlay-header` | Fullscreen mode header | vaadin-date-picker-overlay\n`label` | Fullscreen mode value/label | vaadin-date-picker-overlay\n`clear-button` | Fullscreen mode clear button | vaadin-date-picker-overlay\n`toggle-button` | Fullscreen mode toggle button | vaadin-date-picker-overlay\n`years-toggle-button` | Fullscreen mode years scroller toggle | vaadin-date-picker-overlay\n`months` | Months scroller | vaadin-date-picker-overlay\n`years` | Years scroller | vaadin-date-picker-overlay\n`toolbar` | Footer bar with buttons | vaadin-date-picker-overlay\n`today-button` | Today button | vaadin-date-picker-overlay\n`cancel-button` | Cancel button | vaadin-date-picker-overlay\n`month` | Month calendar | vaadin-date-picker-overlay\n`year-number` | Year number | vaadin-date-picker-overlay\n`year-separator` | Year separator | vaadin-date-picker-overlay\n`month-header` | Month title | vaadin-month-calendar\n`weekdays` | Weekday container | vaadin-month-calendar\n`weekday` | Weekday element | vaadin-month-calendar\n`week-numbers` | Week numbers container | vaadin-month-calendar\n`week-number` | Week number element | vaadin-month-calendar\n`date` | Date element | vaadin-month-calendar\n\nIf you want to replace the default input field with a custom implementation, you should use the\n[`<vaadin-date-picker-light>`](#vaadin-date-picker-light) element.",
+          "summary": "",
+          "path": "vaadin-date-picker.html",
+          "properties": [
+            {
+              "name": "_selectedDate",
+              "type": "Date",
+              "description": "The current selected date.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 25,
+                  "column": 8
+                },
+                "end": {
+                  "line": 27,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_focusedDate",
+              "type": "Date",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 29,
+                  "column": 8
+                },
+                "end": {
+                  "line": 29,
+                  "column": 26
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "The value for this element.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 40,
+                  "column": 8
+                },
+                "end": {
+                  "line": 45,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true,
+                  "observer": "\"_valueChanged\""
+                }
+              },
+              "defaultValue": "\"\"",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "required",
+              "type": "boolean",
+              "description": "Set to true to mark the input as required.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 50,
+                  "column": 8
+                },
+                "end": {
+                  "line": 53,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "The name of this element.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 60,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "hasValue",
+              "type": "boolean",
+              "description": "Indicates whether this date picker has a value.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 66,
+                  "column": 8
+                },
+                "end": {
+                  "line": 70,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "initialPosition",
+              "type": "string",
+              "description": "Date which should be visible when there is no value selected.\n\nThe same date formats as for the `value` property are supported.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 77,
+                  "column": 8
+                },
+                "end": {
+                  "line": 77,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "label",
+              "type": "string",
+              "description": "The label for this element.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 82,
+                  "column": 8
+                },
+                "end": {
+                  "line": 82,
+                  "column": 21
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "opened",
+              "type": "boolean",
+              "description": "Set true to open the date selector overlay.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 87,
+                  "column": 8
+                },
+                "end": {
+                  "line": 91,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true
+                }
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "showWeekNumbers",
+              "type": "boolean",
+              "description": "Set true to display ISO-8601 week numbers in the calendar. Notice that\ndisplaying week numbers is only supported when `i18n.firstDayOfWeek`\nis 1 (Monday).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 98,
+                  "column": 8
+                },
+                "end": {
+                  "line": 100,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_fullscreen",
+              "type": "?",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 102,
+                  "column": 8
+                },
+                "end": {
+                  "line": 105,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_fullscreenChanged\""
+                }
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_fullscreenMediaQuery",
+              "type": "?",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 107,
+                  "column": 8
+                },
+                "end": {
+                  "line": 109,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"(max-width: 420px), (max-height: 420px)\"",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_touchPrevented",
+              "type": "Array",
+              "description": "'touch' to value 'auto' in order to prevent them from clipping the dropdown. iOS only.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 113,
+                  "column": 8
+                },
+                "end": {
+                  "line": 113,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "i18n",
+              "type": "Object",
+              "description": "The object used to localize this component.\nTo change the default localization, replace the entire\n_i18n_ object or just the property you want to modify.\n\nThe object has the following JSON structure and default values:\n\n            {\n              // An array with the full names of months starting\n              // with January.\n              monthNames: [\n                'January', 'February', 'March', 'April', 'May',\n                'June', 'July', 'August', 'September',\n                'October', 'November', 'December'\n              ],\n\n              // An array of weekday names starting with Sunday. Used\n              // in screen reader announcements.\n              weekdays: [\n                'Sunday', 'Monday', 'Tuesday', 'Wednesday',\n                'Thursday', 'Friday', 'Saturday'\n              ],\n\n              // An array of short weekday names starting with Sunday.\n              // Displayed in the calendar.\n              weekdaysShort: [\n                'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'\n              ],\n\n              // An integer indicating the first day of the week\n              // (0 = Sunday, 1 = Monday, etc.).\n              firstDayOfWeek: 0,\n\n              // Used in screen reader announcements along with week\n              // numbers, if they are displayed.\n              week: 'Week',\n\n              // Translation of the Calendar icon button title.\n              calendar: 'Calendar',\n\n              // Translation of the Clear icon button title.\n              clear: 'Clear',\n\n              // Translation of the Today shortcut button text.\n              today: 'Today',\n\n              // Translation of the Cancel button text.\n              cancel: 'Cancel',\n\n              // A function to format given `Date` object as\n              // date string.\n              formatDate: d => {\n                // returns a string representation of the given\n                // Date object in 'MM/DD/YYYY' -format\n              },\n\n              // A function to parse the given text to a `Date`\n              // object. Must properly parse (at least) text\n              // formatted by `formatDate`.\n              // Setting the property to null will disable\n              // keyboard input feature.\n              parseDate: text => {\n                // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to\n                // a Date object\n              }\n\n              // A function to format given `monthName` and\n              // `fullYear` integer as calendar title string.\n              formatTitle: (monthName, fullYear) => {\n                return monthName + ' ' + fullYear;\n              }\n            }",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 191,
+                  "column": 8
+                },
+                "end": {
+                  "line": 244,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "min",
+              "type": "string",
+              "description": "The earliest date that can be selected. All earlier dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 255,
+                  "column": 8
+                },
+                "end": {
+                  "line": 258,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_minChanged\""
+                }
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "max",
+              "type": "string",
+              "description": "The latest date that can be selected. All later dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 269,
+                  "column": 8
+                },
+                "end": {
+                  "line": 272,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_maxChanged\""
+                }
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_minDate",
+              "type": "Date",
+              "description": "The earliest date that can be selected. All earlier dates will be disabled.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 277,
+                  "column": 8
+                },
+                "end": {
+                  "line": 281,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"\"",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_maxDate",
+              "type": "Date",
+              "description": "The latest date that can be selected. All later dates will be disabled.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 286,
+                  "column": 8
+                },
+                "end": {
+                  "line": 289,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"\"",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_noInput",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 291,
+                  "column": 8
+                },
+                "end": {
+                  "line": 294,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_ios",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 296,
+                  "column": 8
+                },
+                "end": {
+                  "line": 299,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_ignoreAnnounce",
+              "type": "?",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 301,
+                  "column": 8
+                },
+                "end": {
+                  "line": 303,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "true",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_focusOverlayOnOpen",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 305,
+                  "column": 8
+                },
+                "end": {
+                  "line": 305,
+                  "column": 36
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_documentPointerEvents",
+              "type": "string",
+              "description": "When datepicker is opened, we're setting body pointer-events to none\nto make the datepicker behave in \"modal\" way. This variable keeps the\nprevious state of body pointer-events to restore it when datepicker is\nclosed.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 313,
+                  "column": 8
+                },
+                "end": {
+                  "line": 313,
+                  "column": 38
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "disabled",
+              "type": "boolean",
+              "description": "Set to true to disable this element.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 182,
+                  "column": 12
+                },
+                "end": {
+                  "line": 186,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "errorMessage",
+              "type": "string",
+              "description": "The error message to display when the input is invalid.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 191,
+                  "column": 12
+                },
+                "end": {
+                  "line": 191,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "placeholder",
+              "type": "string",
+              "description": "A placeholder string in addition to the label. If this is set, the label will always float.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 196,
+                  "column": 12
+                },
+                "end": {
+                  "line": 196,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "readonly",
+              "type": "boolean",
+              "description": "Set to true to make this element read-only.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 201,
+                  "column": 12
+                },
+                "end": {
+                  "line": 205,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "invalid",
+              "type": "boolean",
+              "description": "This property is set to true when the control value invalid.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 210,
+                  "column": 12
+                },
+                "end": {
+                  "line": 215,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true
+                }
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "_userInputValue",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 217,
+                  "column": 12
+                },
+                "end": {
+                  "line": 217,
+                  "column": 35
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "ready",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 227,
+                  "column": 8
+                },
+                "end": {
+                  "line": 232,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "open",
+              "description": "Opens the dropdown.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 341,
+                  "column": 4
+                },
+                "end": {
+                  "line": 346,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_close",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 348,
+                  "column": 4
+                },
+                "end": {
+                  "line": 354,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "close",
+              "description": "Closes the dropdown.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 359,
+                  "column": 4
+                },
+                "end": {
+                  "line": 361,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_parseDate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 377,
+                  "column": 4
+                },
+                "end": {
+                  "line": 389,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "str"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_isNoInput",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 391,
+                  "column": 4
+                },
+                "end": {
+                  "line": 393,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_formatISO",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 395,
+                  "column": 4
+                },
+                "end": {
+                  "line": 399,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "date"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_selectedDateChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 401,
+                  "column": 4
+                },
+                "end": {
+                  "line": 408,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selectedDate"
+                },
+                {
+                  "name": "formatDate"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_focusedDateChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 410,
+                  "column": 4
+                },
+                "end": {
+                  "line": 417,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "focusedDate"
+                },
+                {
+                  "name": "formatDate"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_hasValue",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 419,
+                  "column": 4
+                },
+                "end": {
+                  "line": 421,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_handleDateChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 423,
+                  "column": 4
+                },
+                "end": {
+                  "line": 437,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property"
+                },
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_valueChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 439,
+                  "column": 4
+                },
+                "end": {
+                  "line": 441,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_minChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 443,
+                  "column": 4
+                },
+                "end": {
+                  "line": 445,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_maxChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 447,
+                  "column": 4
+                },
+                "end": {
+                  "line": 449,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_updateAlignmentAndPosition",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 451,
+                  "column": 4
+                },
+                "end": {
+                  "line": 473,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_fullscreenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 475,
+                  "column": 4
+                },
+                "end": {
+                  "line": 479,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_onOverlayOpened",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 481,
+                  "column": 4
+                },
+                "end": {
+                  "line": 529,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_preventWebkitOverflowScrollingTouch",
+              "description": "ancestor container with -webkit-overflow-scrolling: touch;",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 533,
+                  "column": 4
+                },
+                "end": {
+                  "line": 547,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "element"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_onOverlayClosed",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 549,
+                  "column": 4
+                },
+                "end": {
+                  "line": 587,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "detached",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 589,
+                  "column": 4
+                },
+                "end": {
+                  "line": 591,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "validate",
+              "description": "Returns true if `value` is valid, and sets the `invalid` flag appropriatelly.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 599,
+                  "column": 4
+                },
+                "end": {
+                  "line": 602,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "Value to validate. Optional, defaults to user's input value."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the value is valid and sets the `invalid` flag appropriatelly"
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "checkValidity",
+              "description": "Returns true if the current input value satisfies all constraints (if any)\n\nOverride the `checkValidity` method for custom validations.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 612,
+                  "column": 4
+                },
+                "end": {
+                  "line": 629,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "Value to validate. Optional, defaults to the selected date."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the value is valid"
+              },
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_onScroll",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 631,
+                  "column": 4
+                },
+                "end": {
+                  "line": 635,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_preventCancelOnComponentAccess",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 637,
+                  "column": 4
+                },
+                "end": {
+                  "line": 642,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_focus",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 644,
+                  "column": 4
+                },
+                "end": {
+                  "line": 650,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_focusAndSelect",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 652,
+                  "column": 4
+                },
+                "end": {
+                  "line": 655,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_setSelectionRange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 657,
+                  "column": 4
+                },
+                "end": {
+                  "line": 661,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "a"
+                },
+                {
+                  "name": "b"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_preventDefault",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 663,
+                  "column": 4
+                },
+                "end": {
+                  "line": 665,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_eventKey",
+              "description": "Keyboard Navigation",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 670,
+                  "column": 4
+                },
+                "end": {
+                  "line": 679,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_isValidDate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 681,
+                  "column": 4
+                },
+                "end": {
+                  "line": 683,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "d"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_onKeydown",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 685,
+                  "column": 4
+                },
+                "end": {
+                  "line": 738,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_validateInput",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 740,
+                  "column": 4
+                },
+                "end": {
+                  "line": 744,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "date"
+                },
+                {
+                  "name": "min"
+                },
+                {
+                  "name": "max"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_onUserInput",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 746,
+                  "column": 4
+                },
+                "end": {
+                  "line": 757,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_userInputValueChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 759,
+                  "column": 4
+                },
+                "end": {
+                  "line": 768,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_announceFocusedDate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 770,
+                  "column": 4
+                },
+                "end": {
+                  "line": 774,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "_focusedDate"
+                },
+                {
+                  "name": "opened"
+                },
+                {
+                  "name": "_ignoreAnnounce"
+                }
+              ],
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "_addEventListenerToNode",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/gesture-event-listeners.html",
+                "start": {
+                  "line": 47,
+                  "column": 6
+                },
+                "end": {
+                  "line": 51,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node"
+                },
+                {
+                  "name": "eventName"
+                },
+                {
+                  "name": "handler"
+                }
+              ],
+              "inheritedFrom": "Polymer.GestureEventListeners"
+            },
+            {
+              "name": "_removeEventListenerFromNode",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/gesture-event-listeners.html",
+                "start": {
+                  "line": 53,
+                  "column": 6
+                },
+                "end": {
+                  "line": 57,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node"
+                },
+                {
+                  "name": "eventName"
+                },
+                {
+                  "name": "handler"
+                }
+              ],
+              "inheritedFrom": "Polymer.GestureEventListeners"
+            },
+            {
+              "name": "_clear",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 234,
+                  "column": 8
+                },
+                "end": {
+                  "line": 238,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "name": "_toggle",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 240,
+                  "column": 8
+                },
+                "end": {
+                  "line": 243,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "name": "_input",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 245,
+                  "column": 8
+                },
+                "end": {
+                  "line": 247,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_getAriaExpanded",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 257,
+                  "column": 8
+                },
+                "end": {
+                  "line": 259,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "opened"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "includeStyle",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
+                "start": {
+                  "line": 40,
+                  "column": 4
+                },
+                "end": {
+                  "line": 44,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "moduleName"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ThemableMixin"
+            }
+          ],
+          "demos": [
+            {
+              "url": "demo/index.html",
+              "description": ""
+            }
+          ],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 171,
+              "column": 6
+            },
+            "end": {
+              "line": 260,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "HTMLElement",
+          "name": "Vaadin.DatePickerElement",
+          "attributes": [
+            {
+              "name": "value",
+              "description": "The value for this element.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 40,
+                  "column": 8
+                },
+                "end": {
+                  "line": 45,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "required",
+              "description": "Set to true to mark the input as required.",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 50,
+                  "column": 8
+                },
+                "end": {
+                  "line": 53,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "name",
+              "description": "The name of this element.",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 60,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "initial-position",
+              "description": "Date which should be visible when there is no value selected.\n\nThe same date formats as for the `value` property are supported.",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 77,
+                  "column": 8
+                },
+                "end": {
+                  "line": 77,
+                  "column": 31
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "label",
+              "description": "The label for this element.",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 82,
+                  "column": 8
+                },
+                "end": {
+                  "line": 82,
+                  "column": 21
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "opened",
+              "description": "Set true to open the date selector overlay.",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 87,
+                  "column": 8
+                },
+                "end": {
+                  "line": 91,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "show-week-numbers",
+              "description": "Set true to display ISO-8601 week numbers in the calendar. Notice that\ndisplaying week numbers is only supported when `i18n.firstDayOfWeek`\nis 1 (Monday).",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 98,
+                  "column": 8
+                },
+                "end": {
+                  "line": 100,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "i18n",
+              "description": "The object used to localize this component.\nTo change the default localization, replace the entire\n_i18n_ object or just the property you want to modify.\n\nThe object has the following JSON structure and default values:\n\n            {\n              // An array with the full names of months starting\n              // with January.\n              monthNames: [\n                'January', 'February', 'March', 'April', 'May',\n                'June', 'July', 'August', 'September',\n                'October', 'November', 'December'\n              ],\n\n              // An array of weekday names starting with Sunday. Used\n              // in screen reader announcements.\n              weekdays: [\n                'Sunday', 'Monday', 'Tuesday', 'Wednesday',\n                'Thursday', 'Friday', 'Saturday'\n              ],\n\n              // An array of short weekday names starting with Sunday.\n              // Displayed in the calendar.\n              weekdaysShort: [\n                'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'\n              ],\n\n              // An integer indicating the first day of the week\n              // (0 = Sunday, 1 = Monday, etc.).\n              firstDayOfWeek: 0,\n\n              // Used in screen reader announcements along with week\n              // numbers, if they are displayed.\n              week: 'Week',\n\n              // Translation of the Calendar icon button title.\n              calendar: 'Calendar',\n\n              // Translation of the Clear icon button title.\n              clear: 'Clear',\n\n              // Translation of the Today shortcut button text.\n              today: 'Today',\n\n              // Translation of the Cancel button text.\n              cancel: 'Cancel',\n\n              // A function to format given `Date` object as\n              // date string.\n              formatDate: d => {\n                // returns a string representation of the given\n                // Date object in 'MM/DD/YYYY' -format\n              },\n\n              // A function to parse the given text to a `Date`\n              // object. Must properly parse (at least) text\n              // formatted by `formatDate`.\n              // Setting the property to null will disable\n              // keyboard input feature.\n              parseDate: text => {\n                // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to\n                // a Date object\n              }\n\n              // A function to format given `monthName` and\n              // `fullYear` integer as calendar title string.\n              formatTitle: (monthName, fullYear) => {\n                return monthName + ' ' + fullYear;\n              }\n            }",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 191,
+                  "column": 8
+                },
+                "end": {
+                  "line": 244,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "Object",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "min",
+              "description": "The earliest date that can be selected. All earlier dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 255,
+                  "column": 8
+                },
+                "end": {
+                  "line": 258,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "max",
+              "description": "The latest date that can be selected. All later dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
+              "sourceRange": {
+                "file": "vaadin-date-picker-mixin.html",
+                "start": {
+                  "line": 269,
+                  "column": 8
+                },
+                "end": {
+                  "line": 272,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.DatePickerMixin"
+            },
+            {
+              "name": "disabled",
+              "description": "Set to true to disable this element.",
+              "sourceRange": {
+                "start": {
+                  "line": 182,
+                  "column": 12
+                },
+                "end": {
+                  "line": 186,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "error-message",
+              "description": "The error message to display when the input is invalid.",
+              "sourceRange": {
+                "start": {
+                  "line": 191,
+                  "column": 12
+                },
+                "end": {
+                  "line": 191,
+                  "column": 32
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "placeholder",
+              "description": "A placeholder string in addition to the label. If this is set, the label will always float.",
+              "sourceRange": {
+                "start": {
+                  "line": 196,
+                  "column": 12
+                },
+                "end": {
+                  "line": 196,
+                  "column": 31
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "readonly",
+              "description": "Set to true to make this element read-only.",
+              "sourceRange": {
+                "start": {
+                  "line": 201,
+                  "column": 12
+                },
+                "end": {
+                  "line": 205,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "invalid",
+              "description": "This property is set to true when the control value invalid.",
+              "sourceRange": {
+                "start": {
+                  "line": 210,
+                  "column": 12
+                },
+                "end": {
+                  "line": 215,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            }
+          ],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "invalid-changed",
+              "description": "Fired when the `invalid` property changes.",
+              "metadata": {}
+            }
+          ],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [
+            {
+              "description": "",
+              "name": "prefix",
+              "range": {
+                "file": "vaadin-date-picker.html",
+                "start": {
+                  "line": 81,
+                  "column": 6
+                },
+                "end": {
+                  "line": 81,
+                  "column": 47
+                }
+              }
+            }
+          ],
+          "tagname": "vaadin-date-picker",
+          "mixins": [
+            "Vaadin.ThemableMixin",
+            "Vaadin.DatePickerMixin",
+            "Polymer.GestureEventListeners"
           ]
         }
       ],
@@ -3668,14 +3648,14 @@
               "name": "hasValue",
               "type": "boolean",
               "description": "Indicates whether this date picker has a value.",
-              "privacy": "public",
+              "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 65,
+                  "line": 66,
                   "column": 8
                 },
                 "end": {
-                  "line": 69,
+                  "line": 70,
                   "column": 9
                 }
               },
@@ -3692,11 +3672,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 76,
+                  "line": 77,
                   "column": 8
                 },
                 "end": {
-                  "line": 76,
+                  "line": 77,
                   "column": 31
                 }
               },
@@ -3711,11 +3691,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 81,
+                  "line": 82,
                   "column": 8
                 },
                 "end": {
-                  "line": 81,
+                  "line": 82,
                   "column": 21
                 }
               },
@@ -3730,11 +3710,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 86,
+                  "line": 87,
                   "column": 8
                 },
                 "end": {
-                  "line": 90,
+                  "line": 91,
                   "column": 9
                 }
               },
@@ -3751,11 +3731,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 97,
+                  "line": 98,
                   "column": 8
                 },
                 "end": {
-                  "line": 99,
+                  "line": 100,
                   "column": 9
                 }
               },
@@ -3770,11 +3750,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 101,
+                  "line": 102,
                   "column": 8
                 },
                 "end": {
-                  "line": 104,
+                  "line": 105,
                   "column": 9
                 }
               },
@@ -3792,11 +3772,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 106,
+                  "line": 107,
                   "column": 8
                 },
                 "end": {
-                  "line": 108,
+                  "line": 109,
                   "column": 9
                 }
               },
@@ -3812,11 +3792,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 112,
+                  "line": 113,
                   "column": 8
                 },
                 "end": {
-                  "line": 112,
+                  "line": 113,
                   "column": 30
                 }
               },
@@ -3831,11 +3811,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 190,
+                  "line": 191,
                   "column": 8
                 },
                 "end": {
-                  "line": 246,
+                  "line": 244,
                   "column": 9
                 }
               },
@@ -3850,11 +3830,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 257,
+                  "line": 255,
                   "column": 8
                 },
                 "end": {
-                  "line": 260,
+                  "line": 258,
                   "column": 9
                 }
               },
@@ -3871,11 +3851,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 271,
+                  "line": 269,
                   "column": 8
                 },
                 "end": {
-                  "line": 274,
+                  "line": 272,
                   "column": 9
                 }
               },
@@ -3892,11 +3872,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 279,
+                  "line": 277,
                   "column": 8
                 },
                 "end": {
-                  "line": 283,
+                  "line": 281,
                   "column": 9
                 }
               },
@@ -3912,11 +3892,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 288,
+                  "line": 286,
                   "column": 8
                 },
                 "end": {
-                  "line": 291,
+                  "line": 289,
                   "column": 9
                 }
               },
@@ -3932,11 +3912,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 293,
+                  "line": 291,
                   "column": 8
                 },
                 "end": {
-                  "line": 296,
+                  "line": 294,
                   "column": 9
                 }
               },
@@ -3953,11 +3933,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 298,
+                  "line": 296,
                   "column": 8
                 },
                 "end": {
-                  "line": 301,
+                  "line": 299,
                   "column": 9
                 }
               },
@@ -3972,11 +3952,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 303,
+                  "line": 301,
                   "column": 8
                 },
                 "end": {
-                  "line": 305,
+                  "line": 303,
                   "column": 9
                 }
               },
@@ -3992,11 +3972,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 307,
+                  "line": 305,
                   "column": 8
                 },
                 "end": {
-                  "line": 307,
+                  "line": 305,
                   "column": 36
                 }
               },
@@ -4011,11 +3991,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 315,
+                  "line": 313,
                   "column": 8
                 },
                 "end": {
-                  "line": 315,
+                  "line": 313,
                   "column": 38
                 }
               },
@@ -4031,11 +4011,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 328,
+                  "line": 326,
                   "column": 4
                 },
                 "end": {
-                  "line": 338,
+                  "line": 336,
                   "column": 5
                 }
               },
@@ -4048,11 +4028,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 343,
+                  "line": 341,
                   "column": 4
                 },
                 "end": {
-                  "line": 348,
+                  "line": 346,
                   "column": 5
                 }
               },
@@ -4065,11 +4045,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 350,
+                  "line": 348,
                   "column": 4
                 },
                 "end": {
-                  "line": 356,
+                  "line": 354,
                   "column": 5
                 }
               },
@@ -4086,11 +4066,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 361,
+                  "line": 359,
                   "column": 4
                 },
                 "end": {
-                  "line": 363,
+                  "line": 361,
                   "column": 5
                 }
               },
@@ -4103,11 +4083,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 379,
+                  "line": 377,
                   "column": 4
                 },
                 "end": {
-                  "line": 391,
+                  "line": 389,
                   "column": 5
                 }
               },
@@ -4124,11 +4104,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 393,
+                  "line": 391,
                   "column": 4
                 },
                 "end": {
-                  "line": 395,
+                  "line": 393,
                   "column": 5
                 }
               },
@@ -4141,11 +4121,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 397,
+                  "line": 395,
                   "column": 4
                 },
                 "end": {
-                  "line": 401,
+                  "line": 399,
                   "column": 5
                 }
               },
@@ -4162,11 +4142,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 403,
+                  "line": 401,
                   "column": 4
                 },
                 "end": {
-                  "line": 410,
+                  "line": 408,
                   "column": 5
                 }
               },
@@ -4186,11 +4166,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 412,
+                  "line": 410,
                   "column": 4
                 },
                 "end": {
-                  "line": 419,
+                  "line": 417,
                   "column": 5
                 }
               },
@@ -4210,11 +4190,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 421,
+                  "line": 419,
                   "column": 4
                 },
                 "end": {
-                  "line": 423,
+                  "line": 421,
                   "column": 5
                 }
               },
@@ -4231,11 +4211,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 425,
+                  "line": 423,
                   "column": 4
                 },
                 "end": {
-                  "line": 439,
+                  "line": 437,
                   "column": 5
                 }
               },
@@ -4258,11 +4238,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 441,
+                  "line": 439,
                   "column": 4
                 },
                 "end": {
-                  "line": 443,
+                  "line": 441,
                   "column": 5
                 }
               },
@@ -4282,11 +4262,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 445,
+                  "line": 443,
                   "column": 4
                 },
                 "end": {
-                  "line": 447,
+                  "line": 445,
                   "column": 5
                 }
               },
@@ -4306,11 +4286,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 449,
+                  "line": 447,
                   "column": 4
                 },
                 "end": {
-                  "line": 451,
+                  "line": 449,
                   "column": 5
                 }
               },
@@ -4330,11 +4310,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 453,
+                  "line": 451,
                   "column": 4
                 },
                 "end": {
-                  "line": 475,
+                  "line": 473,
                   "column": 5
                 }
               },
@@ -4347,11 +4327,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 477,
+                  "line": 475,
                   "column": 4
                 },
                 "end": {
-                  "line": 481,
+                  "line": 479,
                   "column": 5
                 }
               },
@@ -4364,11 +4344,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 483,
+                  "line": 481,
                   "column": 4
                 },
                 "end": {
-                  "line": 526,
+                  "line": 529,
                   "column": 5
                 }
               },
@@ -4381,11 +4361,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 530,
+                  "line": 533,
                   "column": 4
                 },
                 "end": {
-                  "line": 544,
+                  "line": 547,
                   "column": 5
                 }
               },
@@ -4402,11 +4382,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 546,
+                  "line": 549,
                   "column": 4
                 },
                 "end": {
-                  "line": 584,
+                  "line": 587,
                   "column": 5
                 }
               },
@@ -4419,11 +4399,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 586,
+                  "line": 589,
                   "column": 4
                 },
                 "end": {
-                  "line": 588,
+                  "line": 591,
                   "column": 5
                 }
               },
@@ -4436,18 +4416,20 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 595,
+                  "line": 599,
                   "column": 4
                 },
                 "end": {
-                  "line": 598,
+                  "line": 602,
                   "column": 5
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Value to validate. Optional, defaults to user's input value."
                 }
               ],
               "return": {
@@ -4461,20 +4443,26 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 605,
+                  "line": 612,
                   "column": 4
                 },
                 "end": {
-                  "line": 622,
+                  "line": 629,
                   "column": 5
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "value"
+                  "name": "value",
+                  "type": "string",
+                  "description": "Value to validate. Optional, defaults to the selected date."
                 }
-              ]
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the value is valid"
+              }
             },
             {
               "name": "_onScroll",
@@ -4482,11 +4470,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 624,
+                  "line": 631,
                   "column": 4
                 },
                 "end": {
-                  "line": 628,
+                  "line": 635,
                   "column": 5
                 }
               },
@@ -4503,11 +4491,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 630,
+                  "line": 637,
                   "column": 4
                 },
                 "end": {
-                  "line": 635,
+                  "line": 642,
                   "column": 5
                 }
               },
@@ -4524,11 +4512,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 637,
+                  "line": 644,
                   "column": 4
                 },
                 "end": {
-                  "line": 643,
+                  "line": 650,
                   "column": 5
                 }
               },
@@ -4541,11 +4529,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 645,
+                  "line": 652,
                   "column": 4
                 },
                 "end": {
-                  "line": 648,
+                  "line": 655,
                   "column": 5
                 }
               },
@@ -4558,11 +4546,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 650,
+                  "line": 657,
                   "column": 4
                 },
                 "end": {
-                  "line": 654,
+                  "line": 661,
                   "column": 5
                 }
               },
@@ -4582,11 +4570,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 656,
+                  "line": 663,
                   "column": 4
                 },
                 "end": {
-                  "line": 658,
+                  "line": 665,
                   "column": 5
                 }
               },
@@ -4603,11 +4591,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 663,
+                  "line": 670,
                   "column": 4
                 },
                 "end": {
-                  "line": 672,
+                  "line": 679,
                   "column": 5
                 }
               },
@@ -4624,11 +4612,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 674,
+                  "line": 681,
                   "column": 4
                 },
                 "end": {
-                  "line": 676,
+                  "line": 683,
                   "column": 5
                 }
               },
@@ -4645,11 +4633,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 678,
+                  "line": 685,
                   "column": 4
                 },
                 "end": {
-                  "line": 731,
+                  "line": 738,
                   "column": 5
                 }
               },
@@ -4666,11 +4654,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 733,
+                  "line": 740,
                   "column": 4
                 },
                 "end": {
-                  "line": 737,
+                  "line": 744,
                   "column": 5
                 }
               },
@@ -4693,11 +4681,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 739,
+                  "line": 746,
                   "column": 4
                 },
                 "end": {
-                  "line": 750,
+                  "line": 757,
                   "column": 5
                 }
               },
@@ -4714,11 +4702,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 752,
+                  "line": 759,
                   "column": 4
                 },
                 "end": {
-                  "line": 761,
+                  "line": 768,
                   "column": 5
                 }
               },
@@ -4735,11 +4723,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 763,
+                  "line": 770,
                   "column": 4
                 },
                 "end": {
-                  "line": 767,
+                  "line": 774,
                   "column": 5
                 }
               },
@@ -4766,7 +4754,7 @@
               "column": 2
             },
             "end": {
-              "line": 768,
+              "line": 775,
               "column": 3
             }
           },
@@ -4822,31 +4810,15 @@
               "type": "string"
             },
             {
-              "name": "has-value",
-              "description": "Indicates whether this date picker has a value.",
-              "sourceRange": {
-                "start": {
-                  "line": 65,
-                  "column": 8
-                },
-                "end": {
-                  "line": 69,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            },
-            {
               "name": "initial-position",
               "description": "Date which should be visible when there is no value selected.\n\nThe same date formats as for the `value` property are supported.",
               "sourceRange": {
                 "start": {
-                  "line": 76,
+                  "line": 77,
                   "column": 8
                 },
                 "end": {
-                  "line": 76,
+                  "line": 77,
                   "column": 31
                 }
               },
@@ -4858,11 +4830,11 @@
               "description": "The label for this element.",
               "sourceRange": {
                 "start": {
-                  "line": 81,
+                  "line": 82,
                   "column": 8
                 },
                 "end": {
-                  "line": 81,
+                  "line": 82,
                   "column": 21
                 }
               },
@@ -4874,11 +4846,11 @@
               "description": "Set true to open the date selector overlay.",
               "sourceRange": {
                 "start": {
-                  "line": 86,
+                  "line": 87,
                   "column": 8
                 },
                 "end": {
-                  "line": 90,
+                  "line": 91,
                   "column": 9
                 }
               },
@@ -4890,11 +4862,11 @@
               "description": "Set true to display ISO-8601 week numbers in the calendar. Notice that\ndisplaying week numbers is only supported when `i18n.firstDayOfWeek`\nis 1 (Monday).",
               "sourceRange": {
                 "start": {
-                  "line": 97,
+                  "line": 98,
                   "column": 8
                 },
                 "end": {
-                  "line": 99,
+                  "line": 100,
                   "column": 9
                 }
               },
@@ -4906,11 +4878,11 @@
               "description": "The object used to localize this component.\nTo change the default localization, replace the entire\n_i18n_ object or just the property you want to modify.\n\nThe object has the following JSON structure and default values:\n\n            {\n              // An array with the full names of months starting\n              // with January.\n              monthNames: [\n                'January', 'February', 'March', 'April', 'May',\n                'June', 'July', 'August', 'September',\n                'October', 'November', 'December'\n              ],\n\n              // An array of weekday names starting with Sunday. Used\n              // in screen reader announcements.\n              weekdays: [\n                'Sunday', 'Monday', 'Tuesday', 'Wednesday',\n                'Thursday', 'Friday', 'Saturday'\n              ],\n\n              // An array of short weekday names starting with Sunday.\n              // Displayed in the calendar.\n              weekdaysShort: [\n                'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'\n              ],\n\n              // An integer indicating the first day of the week\n              // (0 = Sunday, 1 = Monday, etc.).\n              firstDayOfWeek: 0,\n\n              // Used in screen reader announcements along with week\n              // numbers, if they are displayed.\n              week: 'Week',\n\n              // Translation of the Calendar icon button title.\n              calendar: 'Calendar',\n\n              // Translation of the Clear icon button title.\n              clear: 'Clear',\n\n              // Translation of the Today shortcut button text.\n              today: 'Today',\n\n              // Translation of the Cancel button text.\n              cancel: 'Cancel',\n\n              // A function to format given `Date` object as\n              // date string.\n              formatDate: d => {\n                // returns a string representation of the given\n                // Date object in 'MM/DD/YYYY' -format\n              },\n\n              // A function to parse the given text to a `Date`\n              // object. Must properly parse (at least) text\n              // formatted by `formatDate`.\n              // Setting the property to null will disable\n              // keyboard input feature.\n              parseDate: text => {\n                // Parses a string in 'MM/DD/YY', 'MM/DD' or 'DD' -format to\n                // a Date object\n              }\n\n              // A function to format given `monthName` and\n              // `fullYear` integer as calendar title string.\n              formatTitle: (monthName, fullYear) => {\n                return monthName + ' ' + fullYear;\n              }\n            }",
               "sourceRange": {
                 "start": {
-                  "line": 190,
+                  "line": 191,
                   "column": 8
                 },
                 "end": {
-                  "line": 246,
+                  "line": 244,
                   "column": 9
                 }
               },
@@ -4922,11 +4894,11 @@
               "description": "The earliest date that can be selected. All earlier dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
               "sourceRange": {
                 "start": {
-                  "line": 257,
+                  "line": 255,
                   "column": 8
                 },
                 "end": {
-                  "line": 260,
+                  "line": 258,
                   "column": 9
                 }
               },
@@ -4938,11 +4910,11 @@
               "description": "The latest date that can be selected. All later dates will be disabled.\n\nSupported date formats:\n- ISO 8601 `\"YYYY-MM-DD\"` (default)\n- 6-digit extended ISO 8601 `\"+YYYYYY-MM-DD\"`, `\"-YYYYYY-MM-DD\"`",
               "sourceRange": {
                 "start": {
-                  "line": 271,
+                  "line": 269,
                   "column": 8
                 },
                 "end": {
-                  "line": 274,
+                  "line": 272,
                   "column": 9
                 }
               },
@@ -5122,11 +5094,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 107,
               "column": 12
             },
             "end": {
-              "line": 106,
+              "line": 110,
               "column": 13
             }
           },
@@ -5141,11 +5113,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 115,
               "column": 12
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 13
             }
           },
@@ -5162,11 +5134,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 12
             },
             "end": {
-              "line": 119,
+              "line": 123,
               "column": 29
             }
           },
@@ -5181,11 +5153,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 125,
               "column": 12
             },
             "end": {
-              "line": 124,
+              "line": 128,
               "column": 13
             }
           },
@@ -5201,11 +5173,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 130,
               "column": 12
             },
             "end": {
-              "line": 128,
+              "line": 132,
               "column": 13
             }
           },
@@ -5220,11 +5192,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 133,
+              "line": 137,
               "column": 12
             },
             "end": {
-              "line": 133,
+              "line": 137,
               "column": 31
             }
           },
@@ -5239,11 +5211,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 12
             },
             "end": {
-              "line": 135,
+              "line": 139,
               "column": 32
             }
           },
@@ -5258,11 +5230,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 140,
+              "line": 144,
               "column": 12
             },
             "end": {
-              "line": 143,
+              "line": 147,
               "column": 13
             }
           },
@@ -5278,11 +5250,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 148,
+              "line": 152,
               "column": 12
             },
             "end": {
-              "line": 151,
+              "line": 155,
               "column": 13
             }
           },
@@ -5298,11 +5270,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 153,
+              "line": 157,
               "column": 12
             },
             "end": {
-              "line": 156,
+              "line": 160,
               "column": 13
             }
           },
@@ -5319,11 +5291,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 158,
+              "line": 162,
               "column": 12
             },
             "end": {
-              "line": 162,
+              "line": 166,
               "column": 13
             }
           },
@@ -5341,11 +5313,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 172,
+              "line": 176,
               "column": 8
             },
             "end": {
-              "line": 174,
+              "line": 178,
               "column": 9
             }
           },
@@ -5365,11 +5337,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 176,
+              "line": 180,
               "column": 8
             },
             "end": {
-              "line": 178,
+              "line": 182,
               "column": 9
             }
           },
@@ -5392,11 +5364,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 181,
+              "line": 185,
               "column": 8
             },
             "end": {
-              "line": 196,
+              "line": 200,
               "column": 9
             }
           },
@@ -5419,11 +5391,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 198,
+              "line": 202,
               "column": 8
             },
             "end": {
-              "line": 203,
+              "line": 207,
               "column": 9
             }
           },
@@ -5443,11 +5415,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 205,
+              "line": 209,
               "column": 8
             },
             "end": {
-              "line": 208,
+              "line": 212,
               "column": 9
             }
           },
@@ -5460,11 +5432,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 210,
+              "line": 214,
               "column": 8
             },
             "end": {
-              "line": 212,
+              "line": 216,
               "column": 9
             }
           },
@@ -5484,11 +5456,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 214,
+              "line": 218,
               "column": 8
             },
             "end": {
-              "line": 220,
+              "line": 224,
               "column": 9
             }
           },
@@ -5508,11 +5480,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 222,
+              "line": 226,
               "column": 8
             },
             "end": {
-              "line": 237,
+              "line": 241,
               "column": 9
             }
           },
@@ -5538,11 +5510,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 239,
+              "line": 243,
               "column": 8
             },
             "end": {
-              "line": 241,
+              "line": 245,
               "column": 9
             }
           },
@@ -5559,11 +5531,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 243,
+              "line": 247,
               "column": 8
             },
             "end": {
-              "line": 249,
+              "line": 253,
               "column": 9
             }
           },
@@ -5583,11 +5555,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 251,
+              "line": 255,
               "column": 8
             },
             "end": {
-              "line": 254,
+              "line": 258,
               "column": 9
             }
           },
@@ -5607,11 +5579,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 256,
+              "line": 260,
               "column": 8
             },
             "end": {
-              "line": 258,
+              "line": 262,
               "column": 9
             }
           },
@@ -5628,11 +5600,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 260,
+              "line": 264,
               "column": 8
             },
             "end": {
-              "line": 285,
+              "line": 289,
               "column": 9
             }
           },
@@ -5652,11 +5624,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 287,
+              "line": 291,
               "column": 8
             },
             "end": {
-              "line": 300,
+              "line": 304,
               "column": 9
             }
           },
@@ -5676,11 +5648,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 302,
+              "line": 306,
               "column": 8
             },
             "end": {
-              "line": 306,
+              "line": 310,
               "column": 9
             }
           },
@@ -5697,11 +5669,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 308,
+              "line": 312,
               "column": 8
             },
             "end": {
-              "line": 313,
+              "line": 317,
               "column": 9
             }
           },
@@ -5718,11 +5690,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 315,
+              "line": 319,
               "column": 8
             },
             "end": {
-              "line": 317,
+              "line": 321,
               "column": 9
             }
           },
@@ -5739,11 +5711,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 319,
+              "line": 323,
               "column": 8
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 9
             }
           },
@@ -5760,11 +5732,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 8
             },
             "end": {
-              "line": 338,
+              "line": 342,
               "column": 9
             }
           },
@@ -5781,11 +5753,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 340,
+              "line": 344,
               "column": 8
             },
             "end": {
-              "line": 345,
+              "line": 349,
               "column": 9
             }
           },
@@ -5808,15 +5780,15 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 91,
+          "line": 95,
           "column": 6
         },
         "end": {
-          "line": 346,
+          "line": 350,
           "column": 7
         }
       },
-      "privacy": "public",
+      "privacy": "private",
       "superclass": "HTMLElement",
       "name": "MonthCalendarElement",
       "attributes": [
@@ -5825,11 +5797,11 @@
           "description": "A `Date` object defining the month to be displayed. Only year and\nmonth properties are actually used.",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 107,
               "column": 12
             },
             "end": {
-              "line": 106,
+              "line": 110,
               "column": 13
             }
           },
@@ -5841,11 +5813,11 @@
           "description": "A `Date` object for the currently selected date.",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 115,
               "column": 12
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 13
             }
           },
@@ -5857,11 +5829,11 @@
           "description": "A `Date` object for the currently focused date.",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 12
             },
             "end": {
-              "line": 119,
+              "line": 123,
               "column": 29
             }
           },
@@ -5873,11 +5845,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 125,
               "column": 12
             },
             "end": {
-              "line": 124,
+              "line": 128,
               "column": 13
             }
           },
@@ -5889,11 +5861,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 130,
               "column": 12
             },
             "end": {
-              "line": 128,
+              "line": 132,
               "column": 13
             }
           },
@@ -5905,11 +5877,11 @@
           "description": "Flag stating whether taps on the component should be ignored.",
           "sourceRange": {
             "start": {
-              "line": 133,
+              "line": 137,
               "column": 12
             },
             "end": {
-              "line": 133,
+              "line": 137,
               "column": 31
             }
           },
@@ -5921,11 +5893,11 @@
           "description": "The earliest date that can be selected. All earlier dates will be disabled.",
           "sourceRange": {
             "start": {
-              "line": 140,
+              "line": 144,
               "column": 12
             },
             "end": {
-              "line": 143,
+              "line": 147,
               "column": 13
             }
           },
@@ -5937,11 +5909,11 @@
           "description": "The latest date that can be selected. All later dates will be disabled.",
           "sourceRange": {
             "start": {
-              "line": 148,
+              "line": 152,
               "column": 12
             },
             "end": {
-              "line": 151,
+              "line": 155,
               "column": 13
             }
           },
@@ -5953,11 +5925,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 158,
+              "line": 162,
               "column": 12
             },
             "end": {
-              "line": 162,
+              "line": 166,
               "column": 13
             }
           },
@@ -5986,17 +5958,776 @@
       "path": "vaadin-infinite-scroller.html",
       "properties": [
         {
+          "name": "__serializing",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 123,
+              "column": 8
+            },
+            "end": {
+              "line": 123,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataCounter",
+          "type": "number",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1151,
+              "column": 8
+            },
+            "end": {
+              "line": 1151,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataEnabled",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 127,
+              "column": 8
+            },
+            "end": {
+              "line": 127,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 129,
+              "column": 8
+            },
+            "end": {
+              "line": 129,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataInvalid",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 131,
+              "column": 8
+            },
+            "end": {
+              "line": 131,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__data",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1133,
+              "column": 8
+            },
+            "end": {
+              "line": 1133,
+              "column": 20
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPending",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1135,
+              "column": 8
+            },
+            "end": {
+              "line": 1135,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataOld",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1137,
+              "column": 8
+            },
+            "end": {
+              "line": 1137,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataProto",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 139,
+              "column": 8
+            },
+            "end": {
+              "line": 139,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataHasAccessor",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 141,
+              "column": 8
+            },
+            "end": {
+              "line": 141,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataInstanceProps",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 143,
+              "column": 8
+            },
+            "end": {
+              "line": 143,
+              "column": 33
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "__dataClientsReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1115,
+              "column": 8
+            },
+            "end": {
+              "line": 1115,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPendingClients",
+          "type": "Array",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1117,
+              "column": 8
+            },
+            "end": {
+              "line": 1117,
+              "column": 34
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataToNotify",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1119,
+              "column": 8
+            },
+            "end": {
+              "line": 1119,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataLinkedPaths",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1121,
+              "column": 8
+            },
+            "end": {
+              "line": 1121,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHasPaths",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1123,
+              "column": 8
+            },
+            "end": {
+              "line": 1123,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataCompoundStorage",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1125,
+              "column": 8
+            },
+            "end": {
+              "line": 1125,
+              "column": 35
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHost",
+          "type": "Polymer_PropertyEffects",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1127,
+              "column": 8
+            },
+            "end": {
+              "line": 1127,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataTemp",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1129,
+              "column": 8
+            },
+            "end": {
+              "line": 1129,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataClientsInitialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1131,
+              "column": 8
+            },
+            "end": {
+              "line": 1131,
+              "column": 38
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__computeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1139,
+              "column": 8
+            },
+            "end": {
+              "line": 1139,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__reflectEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1141,
+              "column": 8
+            },
+            "end": {
+              "line": 1141,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__notifyEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1143,
+              "column": 8
+            },
+            "end": {
+              "line": 1143,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__propagateEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1145,
+              "column": 8
+            },
+            "end": {
+              "line": 1145,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__observeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1147,
+              "column": 8
+            },
+            "end": {
+              "line": 1147,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__readOnly",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1149,
+              "column": 8
+            },
+            "end": {
+              "line": 1149,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__templateInfo",
+          "type": "!TemplateInfo",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1153,
+              "column": 8
+            },
+            "end": {
+              "line": 1153,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_template",
+          "type": "HTMLTemplateElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 549,
+              "column": 8
+            },
+            "end": {
+              "line": 549,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 551,
+              "column": 8
+            },
+            "end": {
+              "line": 551,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "rootPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 553,
+              "column": 8
+            },
+            "end": {
+              "line": 553,
+              "column": 22
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 555,
+              "column": 8
+            },
+            "end": {
+              "line": 555,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "root",
+          "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 557,
+              "column": 8
+            },
+            "end": {
+              "line": 557,
+              "column": 18
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "$",
+          "type": "!Object.<string, !Node>",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 559,
+              "column": 8
+            },
+            "end": {
+              "line": 559,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
           "name": "bufferSize",
           "type": "number",
           "description": "Count of individual items in each buffer.\nThe scroller has 2 buffers altogether so bufferSize of 20\nwill result in 40 buffered DOM items in total.\nChanging after initialization not supported.",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 81,
               "column": 10
             },
             "end": {
-              "line": 82,
+              "line": 84,
               "column": 11
             }
           },
@@ -6012,11 +6743,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 88,
+              "line": 90,
               "column": 10
             },
             "end": {
-              "line": 90,
+              "line": 92,
               "column": 11
             }
           },
@@ -6032,11 +6763,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 95,
+              "line": 97,
               "column": 10
             },
             "end": {
-              "line": 97,
+              "line": 99,
               "column": 11
             }
           },
@@ -6052,11 +6783,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 99,
+              "line": 101,
               "column": 10
             },
             "end": {
-              "line": 99,
+              "line": 101,
               "column": 25
             }
           },
@@ -6071,11 +6802,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 101,
+              "line": 103,
               "column": 10
             },
             "end": {
-              "line": 101,
+              "line": 103,
               "column": 38
             }
           },
@@ -6090,11 +6821,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 105,
               "column": 10
             },
             "end": {
-              "line": 103,
+              "line": 105,
               "column": 35
             }
           },
@@ -6109,11 +6840,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 107,
               "column": 10
             },
             "end": {
-              "line": 105,
+              "line": 107,
               "column": 31
             }
           },
@@ -6128,11 +6859,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 107,
+              "line": 109,
               "column": 10
             },
             "end": {
-              "line": 110,
+              "line": 112,
               "column": 11
             }
           },
@@ -6151,11 +6882,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2235,
+              "line": 2319,
               "column": 6
             },
             "end": {
-              "line": 2260,
+              "line": 2344,
               "column": 7
             }
           },
@@ -6163,12 +6894,12 @@
           "params": [
             {
               "name": "template",
-              "type": "HTMLTemplateElement",
+              "type": "!HTMLTemplateElement",
               "description": "Template to stamp"
             }
           ],
           "return": {
-            "type": "DocumentFragment",
+            "type": "!StampedTemplate",
             "desc": "Cloned template content"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
@@ -6180,11 +6911,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 443,
+              "line": 448,
               "column": 6
             },
             "end": {
-              "line": 448,
+              "line": 453,
               "column": 7
             }
           },
@@ -6224,11 +6955,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 457,
+              "line": 462,
               "column": 6
             },
             "end": {
-              "line": 459,
+              "line": 464,
               "column": 7
             }
           },
@@ -6259,11 +6990,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 468,
+              "line": 473,
               "column": 6
             },
             "end": {
-              "line": 470,
+              "line": 475,
               "column": 7
             }
           },
@@ -6289,29 +7020,35 @@
         },
         {
           "name": "attributeChangedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialzed to \"camelCase\"\nproperties.",
+          "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialized to \"camelCase\"\nproperties.",
           "privacy": "public",
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 716,
+              "line": 715,
               "column": 6
             },
             "end": {
-              "line": 724,
+              "line": 723,
               "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "name"
+              "name": "name",
+              "type": "string",
+              "description": "Name of attribute."
             },
             {
-              "name": "old"
+              "name": "old",
+              "type": "?string",
+              "description": "Old value of attribute."
             },
             {
-              "name": "value"
+              "name": "value",
+              "type": "?string",
+              "description": "Current value of attribute."
             }
           ],
           "inheritedFrom": "Polymer.ElementMixin"
@@ -6323,11 +7060,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 576,
+              "line": 573,
               "column": 6
             },
             "end": {
-              "line": 616,
+              "line": 613,
               "column": 7
             }
           },
@@ -6342,18 +7079,20 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1107,
+              "line": 1183,
               "column": 6
             },
             "end": {
-              "line": 1111,
+              "line": 1187,
               "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "props"
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the prototype"
             }
           ],
           "inheritedFrom": "Polymer.PropertyEffects"
@@ -6365,18 +7104,20 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1119,
+              "line": 1196,
               "column": 6
             },
             "end": {
-              "line": 1128,
+              "line": 1205,
               "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "props"
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the instance"
             }
           ],
           "inheritedFrom": "Polymer.PropertyEffects"
@@ -6388,11 +7129,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 204,
+              "line": 236,
               "column": 6
             },
             "end": {
-              "line": 208,
+              "line": 240,
               "column": 7
             }
           },
@@ -6418,11 +7159,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 220,
+              "line": 252,
               "column": 6
             },
             "end": {
-              "line": 226,
+              "line": 258,
               "column": 7
             }
           },
@@ -6435,12 +7176,12 @@
             },
             {
               "name": "value",
-              "type": "string",
+              "type": "?string",
               "description": "of the attribute."
             },
             {
               "name": "type",
-              "type": "*",
+              "type": "*=",
               "description": "type to deserialize to."
             }
           ],
@@ -6453,11 +7194,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 235,
+              "line": 267,
               "column": 6
             },
             "end": {
-              "line": 241,
+              "line": 273,
               "column": 7
             }
           },
@@ -6488,11 +7229,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 255,
+              "line": 287,
               "column": 6
             },
             "end": {
-              "line": 262,
+              "line": 294,
               "column": 7
             }
           },
@@ -6523,11 +7264,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 274,
+              "line": 306,
               "column": 6
             },
             "end": {
-              "line": 294,
+              "line": 326,
               "column": 7
             }
           },
@@ -6552,11 +7293,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 313,
+              "line": 345,
               "column": 6
             },
             "end": {
-              "line": 355,
+              "line": 387,
               "column": 7
             }
           },
@@ -6564,12 +7305,12 @@
           "params": [
             {
               "name": "value",
-              "type": "string",
+              "type": "?string",
               "description": "Attribute value to deserialize."
             },
             {
               "name": "type",
-              "type": "*",
+              "type": "*=",
               "description": "Type to deserialize the string to."
             }
           ],
@@ -6586,11 +7327,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 379,
+              "line": 411,
               "column": 6
             },
             "end": {
-              "line": 395,
+              "line": 431,
               "column": 7
             }
           },
@@ -6616,11 +7357,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 403,
+              "line": 439,
               "column": 6
             },
             "end": {
-              "line": 405,
+              "line": 441,
               "column": 7
             }
           },
@@ -6645,11 +7386,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1389,
+              "line": 1472,
               "column": 6
             },
             "end": {
-              "line": 1393,
+              "line": 1476,
               "column": 7
             }
           },
@@ -6666,31 +7407,41 @@
         },
         {
           "name": "_setPendingProperty",
-          "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChaged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
+          "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChanged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
           "privacy": "protected",
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1353,
+              "line": 1435,
               "column": 6
             },
             "end": {
-              "line": 1381,
+              "line": 1464,
               "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "property"
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
             },
             {
-              "name": "value"
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
             },
             {
-              "name": "shouldNotify"
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "True if property should fire notification\n  event (applies only for `notify: true` properties)"
             }
           ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property changed"
+          },
           "inheritedFrom": "Polymer.PropertyEffects"
         },
         {
@@ -6700,11 +7451,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 456,
+              "line": 493,
               "column": 6
             },
             "end": {
-              "line": 458,
+              "line": 495,
               "column": 7
             }
           },
@@ -6729,11 +7480,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1403,
+              "line": 1486,
               "column": 6
             },
             "end": {
-              "line": 1407,
+              "line": 1490,
               "column": 7
             }
           },
@@ -6748,11 +7499,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 486,
+              "line": 523,
               "column": 6
             },
             "end": {
-              "line": 495,
+              "line": 532,
               "column": 7
             }
           },
@@ -6767,11 +7518,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 506,
+              "line": 543,
               "column": 6
             },
             "end": {
-              "line": 514,
+              "line": 551,
               "column": 7
             }
           },
@@ -6785,11 +7536,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 116,
               "column": 6
             },
             "end": {
-              "line": 140,
+              "line": 142,
               "column": 7
             }
           },
@@ -6803,11 +7554,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1542,
+              "line": 1625,
               "column": 6
             },
             "end": {
-              "line": 1575,
+              "line": 1658,
               "column": 7
             }
           },
@@ -6832,11 +7583,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 569,
+              "line": 606,
               "column": 6
             },
             "end": {
-              "line": 576,
+              "line": 609,
               "column": 7
             }
           },
@@ -6860,7 +7611,7 @@
           ],
           "return": {
             "type": "boolean",
-            "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+            "desc": "Whether the property should be considered a change\n  and enqueue a `_propertiesChanged` callback"
           },
           "inheritedFrom": "Polymer.PropertyAccessors"
         },
@@ -6871,11 +7622,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1142,
+              "line": 1219,
               "column": 6
             },
             "end": {
-              "line": 1150,
+              "line": 1227,
               "column": 7
             }
           },
@@ -6906,11 +7657,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1159,
+              "line": 1236,
               "column": 6
             },
             "end": {
-              "line": 1165,
+              "line": 1242,
               "column": 7
             }
           },
@@ -6941,11 +7692,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1176,
+              "line": 1253,
               "column": 6
             },
             "end": {
-              "line": 1179,
+              "line": 1256,
               "column": 7
             }
           },
@@ -6975,11 +7726,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1189,
+              "line": 1266,
               "column": 6
             },
             "end": {
-              "line": 1191,
+              "line": 1268,
               "column": 7
             }
           },
@@ -7004,11 +7755,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1201,
+              "line": 1278,
               "column": 6
             },
             "end": {
-              "line": 1203,
+              "line": 1280,
               "column": 7
             }
           },
@@ -7033,11 +7784,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1213,
+              "line": 1290,
               "column": 6
             },
             "end": {
-              "line": 1215,
+              "line": 1292,
               "column": 7
             }
           },
@@ -7062,11 +7813,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1225,
+              "line": 1302,
               "column": 6
             },
             "end": {
-              "line": 1227,
+              "line": 1304,
               "column": 7
             }
           },
@@ -7091,11 +7842,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1259,
+              "line": 1336,
               "column": 6
             },
             "end": {
-              "line": 1291,
+              "line": 1368,
               "column": 7
             }
           },
@@ -7135,11 +7886,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1313,
+              "line": 1390,
               "column": 6
             },
             "end": {
-              "line": 1321,
+              "line": 1398,
               "column": 7
             }
           },
@@ -7170,11 +7921,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1417,
+              "line": 1500,
               "column": 6
             },
             "end": {
-              "line": 1422,
+              "line": 1505,
               "column": 7
             }
           },
@@ -7195,11 +7946,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1430,
+              "line": 1513,
               "column": 6
             },
             "end": {
-              "line": 1441,
+              "line": 1524,
               "column": 7
             }
           },
@@ -7214,11 +7965,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1455,
+              "line": 1538,
               "column": 6
             },
             "end": {
-              "line": 1468,
+              "line": 1551,
               "column": 7
             }
           },
@@ -7233,11 +7984,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 665,
+              "line": 660,
               "column": 6
             },
             "end": {
-              "line": 674,
+              "line": 669,
               "column": 7
             }
           },
@@ -7252,11 +8003,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1495,
+              "line": 1578,
               "column": 6
             },
             "end": {
-              "line": 1506,
+              "line": 1589,
               "column": 7
             }
           },
@@ -7282,11 +8033,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1586,
+              "line": 1669,
               "column": 6
             },
             "end": {
-              "line": 1596,
+              "line": 1679,
               "column": 7
             }
           },
@@ -7317,11 +8068,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1606,
+              "line": 1689,
               "column": 6
             },
             "end": {
-              "line": 1611,
+              "line": 1694,
               "column": 7
             }
           },
@@ -7347,11 +8098,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1622,
+              "line": 1705,
               "column": 6
             },
             "end": {
-              "line": 1627,
+              "line": 1710,
               "column": 7
             }
           },
@@ -7372,11 +8123,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1658,
+              "line": 1741,
               "column": 6
             },
             "end": {
-              "line": 1662,
+              "line": 1745,
               "column": 7
             }
           },
@@ -7402,11 +8153,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1683,
+              "line": 1766,
               "column": 6
             },
             "end": {
-              "line": 1685,
+              "line": 1768,
               "column": 7
             }
           },
@@ -7436,11 +8187,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1707,
+              "line": 1790,
               "column": 6
             },
             "end": {
-              "line": 1717,
+              "line": 1800,
               "column": 7
             }
           },
@@ -7471,11 +8222,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1733,
+              "line": 1816,
               "column": 6
             },
             "end": {
-              "line": 1742,
+              "line": 1825,
               "column": 7
             }
           },
@@ -7483,7 +8234,7 @@
           "params": [
             {
               "name": "path",
-              "type": "string",
+              "type": "(string|!Array.<(string|number)>)",
               "description": "Path to array."
             },
             {
@@ -7503,11 +8254,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1757,
+              "line": 1840,
               "column": 6
             },
             "end": {
-              "line": 1766,
+              "line": 1849,
               "column": 7
             }
           },
@@ -7515,7 +8266,7 @@
           "params": [
             {
               "name": "path",
-              "type": "string",
+              "type": "(string|!Array.<(string|number)>)",
               "description": "Path to array."
             }
           ],
@@ -7532,11 +8283,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1785,
+              "line": 1868,
               "column": 6
             },
             "end": {
-              "line": 1802,
+              "line": 1885,
               "column": 7
             }
           },
@@ -7544,7 +8295,7 @@
           "params": [
             {
               "name": "path",
-              "type": "string",
+              "type": "(string|!Array.<(string|number)>)",
               "description": "Path to array."
             },
             {
@@ -7574,11 +8325,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1817,
+              "line": 1900,
               "column": 6
             },
             "end": {
-              "line": 1826,
+              "line": 1909,
               "column": 7
             }
           },
@@ -7586,7 +8337,7 @@
           "params": [
             {
               "name": "path",
-              "type": "string",
+              "type": "(string|!Array.<(string|number)>)",
               "description": "Path to array."
             }
           ],
@@ -7603,11 +8354,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1842,
+              "line": 1925,
               "column": 6
             },
             "end": {
-              "line": 1850,
+              "line": 1933,
               "column": 7
             }
           },
@@ -7615,7 +8366,7 @@
           "params": [
             {
               "name": "path",
-              "type": "string",
+              "type": "(string|!Array.<(string|number)>)",
               "description": "Path to array."
             },
             {
@@ -7635,11 +8386,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1864,
+              "line": 1947,
               "column": 6
             },
             "end": {
-              "line": 1881,
+              "line": 1964,
               "column": 7
             }
           },
@@ -7665,11 +8416,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1893,
+              "line": 1976,
               "column": 6
             },
             "end": {
-              "line": 1900,
+              "line": 1983,
               "column": 7
             }
           },
@@ -7695,11 +8446,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1913,
+              "line": 1996,
               "column": 6
             },
             "end": {
-              "line": 1923,
+              "line": 2006,
               "column": 7
             }
           },
@@ -7730,11 +8481,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1935,
+              "line": 2018,
               "column": 6
             },
             "end": {
-              "line": 1941,
+              "line": 2024,
               "column": 7
             }
           },
@@ -7760,11 +8511,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1951,
+              "line": 2034,
               "column": 6
             },
             "end": {
-              "line": 1959,
+              "line": 2042,
               "column": 7
             }
           },
@@ -7785,11 +8536,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1969,
+              "line": 2052,
               "column": 6
             },
             "end": {
-              "line": 1982,
+              "line": 2065,
               "column": 7
             }
           },
@@ -7810,11 +8561,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1995,
+              "line": 2078,
               "column": 6
             },
             "end": {
-              "line": 2001,
+              "line": 2084,
               "column": 7
             }
           },
@@ -7845,11 +8596,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2171,
+              "line": 2254,
               "column": 6
             },
             "end": {
-              "line": 2194,
+              "line": 2277,
               "column": 7
             }
           },
@@ -7867,7 +8618,7 @@
             }
           ],
           "return": {
-            "type": "Object",
+            "type": "!TemplateInfo",
             "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
@@ -7879,11 +8630,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2270,
+              "line": 2354,
               "column": 6
             },
             "end": {
-              "line": 2291,
+              "line": 2375,
               "column": 7
             }
           },
@@ -7891,7 +8642,7 @@
           "params": [
             {
               "name": "dom",
-              "type": "DocumentFragment",
+              "type": "!StampedTemplate",
               "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
             }
           ],
@@ -7904,11 +8655,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 628,
+              "line": 625,
               "column": 6
             },
             "end": {
-              "line": 633,
+              "line": 630,
               "column": 7
             }
           },
@@ -7923,11 +8674,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 641,
+              "line": 636,
               "column": 6
             },
             "end": {
-              "line": 641,
+              "line": 636,
               "column": 31
             }
           },
@@ -7942,11 +8693,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 688,
+              "line": 683,
               "column": 6
             },
             "end": {
-              "line": 703,
+              "line": 699,
               "column": 7
             }
           },
@@ -7954,12 +8705,12 @@
           "params": [
             {
               "name": "dom",
-              "type": "NodeList",
+              "type": "StampedTemplate",
               "description": "to attach to the element."
             }
           ],
           "return": {
-            "type": "Node",
+            "type": "ShadowRoot",
             "desc": "node to which the dom has been attached."
           },
           "inheritedFrom": "Polymer.ElementMixin"
@@ -8029,11 +8780,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 142,
+              "line": 144,
               "column": 6
             },
             "end": {
-              "line": 147,
+              "line": 149,
               "column": 7
             }
           },
@@ -8050,11 +8801,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 149,
+              "line": 151,
               "column": 6
             },
             "end": {
-              "line": 163,
+              "line": 165,
               "column": 7
             }
           },
@@ -8067,11 +8818,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 167,
               "column": 6
             },
             "end": {
-              "line": 171,
+              "line": 173,
               "column": 7
             }
           },
@@ -8088,11 +8839,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 173,
+              "line": 175,
               "column": 6
             },
             "end": {
-              "line": 208,
+              "line": 210,
               "column": 7
             }
           },
@@ -8105,11 +8856,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 262,
+              "line": 264,
               "column": 6
             },
             "end": {
-              "line": 281,
+              "line": 283,
               "column": 7
             }
           },
@@ -8122,11 +8873,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 283,
+              "line": 285,
               "column": 6
             },
             "end": {
-              "line": 317,
+              "line": 319,
               "column": 7
             }
           },
@@ -8139,11 +8890,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 319,
+              "line": 321,
               "column": 6
             },
             "end": {
-              "line": 332,
+              "line": 334,
               "column": 7
             }
           },
@@ -8160,11 +8911,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 334,
+              "line": 336,
               "column": 6
             },
             "end": {
-              "line": 351,
+              "line": 353,
               "column": 7
             }
           },
@@ -8181,11 +8932,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 353,
+              "line": 355,
               "column": 6
             },
             "end": {
-              "line": 356,
+              "line": 358,
               "column": 7
             }
           },
@@ -8208,11 +8959,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 195,
+              "line": 197,
               "column": 6
             },
             "end": {
-              "line": 206,
+              "line": 208,
               "column": 7
             }
           },
@@ -8220,17 +8971,17 @@
           "params": [
             {
               "name": "template",
-              "type": "HTMLTemplateElement",
+              "type": "!HTMLTemplateElement",
               "description": "Template to parse"
             },
             {
               "name": "outerTemplateInfo",
-              "type": "Object=",
+              "type": "TemplateInfo=",
               "description": "Template metadata from the outer\n  template, for parsing nested templates"
             }
           ],
           "return": {
-            "type": "Object",
+            "type": "!TemplateInfo",
             "desc": "Parsed template metadata"
           },
           "inheritedFrom": "Polymer.TemplateStamp"
@@ -8242,11 +8993,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 774,
+              "line": 775,
               "column": 6
             },
             "end": {
-              "line": 777,
+              "line": 778,
               "column": 7
             }
           },
@@ -8271,11 +9022,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2309,
+              "line": 2394,
               "column": 6
             },
             "end": {
-              "line": 2323,
+              "line": 2408,
               "column": 7
             }
           },
@@ -8288,12 +9039,12 @@
             },
             {
               "name": "templateInfo",
-              "type": "Object",
+              "type": "TemplateInfo",
               "description": "Template metadata for current template"
             },
             {
               "name": "nodeInfo",
-              "type": "Object",
+              "type": "NodeInfo",
               "description": "Node metadata for current template node"
             }
           ],
@@ -8310,11 +9061,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 254,
+              "line": 257,
               "column": 6
             },
             "end": {
-              "line": 288,
+              "line": 291,
               "column": 7
             }
           },
@@ -8327,12 +9078,12 @@
             },
             {
               "name": "templateInfo",
-              "type": "Object",
+              "type": "!TemplateInfo",
               "description": "Template metadata for current template"
             },
             {
               "name": "nodeInfo",
-              "type": "Object",
+              "type": "!NodeInfo",
               "description": "Node metadata for current template."
             }
           ],
@@ -8345,11 +9096,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2392,
+              "line": 2479,
               "column": 6
             },
             "end": {
-              "line": 2402,
+              "line": 2489,
               "column": 7
             }
           },
@@ -8362,12 +9113,12 @@
             },
             {
               "name": "templateInfo",
-              "type": "Object",
+              "type": "TemplateInfo",
               "description": "Template metadata for current template"
             },
             {
               "name": "nodeInfo",
-              "type": "Object",
+              "type": "NodeInfo",
               "description": "Node metadata for current template node"
             }
           ],
@@ -8384,11 +9135,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 326,
+              "line": 329,
               "column": 6
             },
             "end": {
-              "line": 335,
+              "line": 338,
               "column": 7
             }
           },
@@ -8396,17 +9147,17 @@
           "params": [
             {
               "name": "node",
-              "type": "Node",
+              "type": "Element",
               "description": "Node to parse"
             },
             {
               "name": "templateInfo",
-              "type": "Object",
+              "type": "TemplateInfo",
               "description": "Template metadata for current template"
             },
             {
               "name": "nodeInfo",
-              "type": "Object",
+              "type": "NodeInfo",
               "description": "Node metadata for current template."
             }
           ],
@@ -8423,11 +9174,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2341,
+              "line": 2427,
               "column": 6
             },
             "end": {
-              "line": 2377,
+              "line": 2463,
               "column": 7
             }
           },
@@ -8435,17 +9186,17 @@
           "params": [
             {
               "name": "node",
-              "type": "Node",
+              "type": "Element",
               "description": "Node to parse"
             },
             {
               "name": "templateInfo",
-              "type": "Object",
+              "type": "TemplateInfo",
               "description": "Template metadata for current template"
             },
             {
               "name": "nodeInfo",
-              "type": "Object",
+              "type": "NodeInfo",
               "description": "Node metadata for current template node"
             },
             {
@@ -8468,11 +9219,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 380,
+              "line": 384,
               "column": 6
             },
             "end": {
-              "line": 383,
+              "line": 387,
               "column": 7
             }
           },
@@ -8497,11 +9248,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 110,
+              "line": 113,
               "column": 6
             },
             "end": {
-              "line": 115,
+              "line": 118,
               "column": 7
             }
           },
@@ -8511,16 +9262,16 @@
         },
         {
           "name": "addPropertyEffect",
-          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n  {\n    fn: effectFunction, // Reference to function to call to perform effect\n    info: { ... }       // Effect metadata passed to function\n    trigger: {          // Optional triggering metadata; if not provided\n      name: string      // the property is treated as a wildcard\n      structured: boolean\n      wildcard: boolean\n    }\n  }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n  effectFunction(inst, path, props, oldProps, info, hasPaths)",
+          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
           "privacy": "protected",
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2040,
+              "line": 2123,
               "column": 6
             },
             "end": {
-              "line": 2042,
+              "line": 2125,
               "column": 7
             }
           },
@@ -8551,11 +9302,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2053,
+              "line": 2136,
               "column": 6
             },
             "end": {
-              "line": 2055,
+              "line": 2138,
               "column": 7
             }
           },
@@ -8581,16 +9332,16 @@
         },
         {
           "name": "createMethodObserver",
-          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal Javascript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
           "privacy": "protected",
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2069,
+              "line": 2152,
               "column": 6
             },
             "end": {
-              "line": 2071,
+              "line": 2154,
               "column": 7
             }
           },
@@ -8616,11 +9367,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2080,
+              "line": 2163,
               "column": 6
             },
             "end": {
-              "line": 2082,
+              "line": 2165,
               "column": 7
             }
           },
@@ -8641,11 +9392,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2099,
+              "line": 2182,
               "column": 6
             },
             "end": {
-              "line": 2101,
+              "line": 2184,
               "column": 7
             }
           },
@@ -8671,11 +9422,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2110,
+              "line": 2193,
               "column": 6
             },
             "end": {
-              "line": 2112,
+              "line": 2195,
               "column": 7
             }
           },
@@ -8691,16 +9442,16 @@
         },
         {
           "name": "createComputedProperty",
-          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal Javascript function signature:\n`'methodName(arg1, [..., argn])'`",
+          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
           "privacy": "protected",
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2127,
+              "line": 2210,
               "column": 6
             },
             "end": {
-              "line": 2129,
+              "line": 2212,
               "column": 7
             }
           },
@@ -8731,11 +9482,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2143,
+              "line": 2226,
               "column": 6
             },
             "end": {
-              "line": 2145,
+              "line": 2228,
               "column": 7
             }
           },
@@ -8760,11 +9511,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2208,
+              "line": 2291,
               "column": 6
             },
             "end": {
-              "line": 2214,
+              "line": 2297,
               "column": 7
             }
           },
@@ -8795,11 +9546,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2437,
+              "line": 2524,
               "column": 6
             },
             "end": {
-              "line": 2500,
+              "line": 2589,
               "column": 7
             }
           },
@@ -8817,7 +9568,7 @@
             }
           ],
           "return": {
-            "type": "Array.<Object>",
+            "type": "Array.<!BindingPart>",
             "desc": "Array of binding part metadata"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
@@ -8829,11 +9580,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2516,
+              "line": 2605,
               "column": 6
             },
             "end": {
-              "line": 2533,
+              "line": 2622,
               "column": 7
             }
           },
@@ -8841,12 +9592,12 @@
           "params": [
             {
               "name": "inst",
-              "type": "HTMLElement",
+              "type": "this",
               "description": "Element that should be used as scope for\n  binding dependencies"
             },
             {
               "name": "part",
-              "type": "Object",
+              "type": "BindingPart",
               "description": "Binding part metadata"
             },
             {
@@ -8883,11 +9634,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 492,
+              "line": 471,
               "column": 6
             },
             "end": {
-              "line": 496,
+              "line": 475,
               "column": 7
             }
           },
@@ -8900,15 +9651,15 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 64,
+          "line": 66,
           "column": 4
         },
         "end": {
-          "line": 357,
+          "line": 359,
           "column": 5
         }
       },
-      "privacy": "public",
+      "privacy": "private",
       "superclass": "HTMLElement",
       "name": "InfiniteScrollerElement",
       "attributes": [
@@ -8917,11 +9668,11 @@
           "description": "Count of individual items in each buffer.\nThe scroller has 2 buffers altogether so bufferSize of 20\nwill result in 40 buffered DOM items in total.\nChanging after initialization not supported.",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 81,
               "column": 10
             },
             "end": {
-              "line": 82,
+              "line": 84,
               "column": 11
             }
           },
@@ -8933,11 +9684,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 107,
+              "line": 109,
               "column": 10
             },
             "end": {
-              "line": 110,
+              "line": 112,
               "column": 11
             }
           },
@@ -8965,11 +9716,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 242,
+              "line": 244,
               "column": 12
             },
             "end": {
-              "line": 245,
+              "line": 247,
               "column": 13
             }
           },
@@ -8986,11 +9737,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 250,
+              "line": 252,
               "column": 12
             },
             "end": {
-              "line": 254,
+              "line": 256,
               "column": 13
             }
           },
@@ -9008,11 +9759,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 256,
+              "line": 258,
               "column": 12
             },
             "end": {
-              "line": 256,
+              "line": 258,
               "column": 37
             }
           },
@@ -9027,11 +9778,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 261,
+              "line": 263,
               "column": 12
             },
             "end": {
-              "line": 264,
+              "line": 266,
               "column": 13
             }
           },
@@ -9048,11 +9799,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 266,
+              "line": 268,
               "column": 12
             },
             "end": {
-              "line": 268,
+              "line": 270,
               "column": 13
             }
           },
@@ -9067,11 +9818,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 270,
+              "line": 272,
               "column": 12
             },
             "end": {
-              "line": 270,
+              "line": 272,
               "column": 38
             }
           },
@@ -9086,11 +9837,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 272,
+              "line": 274,
               "column": 12
             },
             "end": {
-              "line": 272,
+              "line": 274,
               "column": 33
             }
           },
@@ -9105,11 +9856,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 274,
+              "line": 276,
               "column": 12
             },
             "end": {
-              "line": 276,
+              "line": 278,
               "column": 13
             }
           },
@@ -9126,11 +9877,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 278,
+              "line": 280,
               "column": 12
             },
             "end": {
-              "line": 280,
+              "line": 282,
               "column": 13
             }
           },
@@ -9146,11 +9897,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 282,
+              "line": 284,
               "column": 12
             },
             "end": {
-              "line": 284,
+              "line": 286,
               "column": 13
             }
           },
@@ -9165,11 +9916,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 286,
+              "line": 288,
               "column": 12
             },
             "end": {
-              "line": 288,
+              "line": 290,
               "column": 13
             }
           },
@@ -9184,11 +9935,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 290,
+              "line": 292,
               "column": 12
             },
             "end": {
-              "line": 290,
+              "line": 292,
               "column": 32
             }
           },
@@ -9203,11 +9954,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 292,
+              "line": 294,
               "column": 12
             },
             "end": {
-              "line": 292,
+              "line": 294,
               "column": 32
             }
           },
@@ -9222,11 +9973,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 297,
+              "line": 299,
               "column": 12
             },
             "end": {
-              "line": 297,
+              "line": 299,
               "column": 25
             }
           },
@@ -9241,11 +9992,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 302,
+              "line": 304,
               "column": 12
             },
             "end": {
-              "line": 302,
+              "line": 304,
               "column": 25
             }
           },
@@ -9260,11 +10011,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 304,
+              "line": 306,
               "column": 12
             },
             "end": {
-              "line": 304,
+              "line": 306,
               "column": 29
             }
           },
@@ -9279,11 +10030,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 309,
+              "line": 311,
               "column": 12
             },
             "end": {
-              "line": 309,
+              "line": 311,
               "column": 25
             }
           },
@@ -9299,11 +10050,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 313,
+              "line": 315,
               "column": 8
             },
             "end": {
-              "line": 320,
+              "line": 322,
               "column": 9
             }
           },
@@ -9312,15 +10063,15 @@
         },
         {
           "name": "connectedCallback",
-          "description": "Fired when the scroller reaches the target scrolling position.",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 329,
+              "line": 331,
               "column": 8
             },
             "end": {
-              "line": 335,
+              "line": 337,
               "column": 9
             }
           },
@@ -9333,11 +10084,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 337,
+              "line": 339,
               "column": 8
             },
             "end": {
-              "line": 361,
+              "line": 363,
               "column": 9
             }
           },
@@ -9350,11 +10101,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 366,
+              "line": 368,
               "column": 8
             },
             "end": {
-              "line": 368,
+              "line": 370,
               "column": 9
             }
           },
@@ -9367,11 +10118,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 373,
+              "line": 375,
               "column": 8
             },
             "end": {
-              "line": 375,
+              "line": 377,
               "column": 9
             }
           },
@@ -9391,11 +10142,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 377,
+              "line": 379,
               "column": 8
             },
             "end": {
-              "line": 379,
+              "line": 381,
               "column": 9
             }
           },
@@ -9412,11 +10163,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 381,
+              "line": 383,
               "column": 8
             },
             "end": {
-              "line": 383,
+              "line": 385,
               "column": 9
             }
           },
@@ -9433,11 +10184,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 385,
+              "line": 387,
               "column": 8
             },
             "end": {
-              "line": 389,
+              "line": 391,
               "column": 9
             }
           },
@@ -9457,11 +10208,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 394,
+              "line": 396,
               "column": 8
             },
             "end": {
-              "line": 408,
+              "line": 410,
               "column": 9
             }
           },
@@ -9478,11 +10229,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 410,
+              "line": 412,
               "column": 8
             },
             "end": {
-              "line": 412,
+              "line": 414,
               "column": 9
             }
           },
@@ -9495,11 +10246,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 414,
+              "line": 416,
               "column": 8
             },
             "end": {
-              "line": 416,
+              "line": 418,
               "column": 9
             }
           },
@@ -9512,11 +10263,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 418,
+              "line": 420,
               "column": 8
             },
             "end": {
-              "line": 420,
+              "line": 422,
               "column": 9
             }
           },
@@ -9533,11 +10284,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 422,
+              "line": 424,
               "column": 8
             },
             "end": {
-              "line": 425,
+              "line": 427,
               "column": 9
             }
           },
@@ -9550,11 +10301,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 427,
+              "line": 429,
               "column": 8
             },
             "end": {
-              "line": 430,
+              "line": 432,
               "column": 9
             }
           },
@@ -9567,11 +10318,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 432,
+              "line": 434,
               "column": 8
             },
             "end": {
-              "line": 435,
+              "line": 437,
               "column": 9
             }
           },
@@ -9584,11 +10335,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 437,
+              "line": 439,
               "column": 8
             },
             "end": {
-              "line": 440,
+              "line": 442,
               "column": 9
             }
           },
@@ -9601,11 +10352,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 442,
+              "line": 444,
               "column": 8
             },
             "end": {
-              "line": 447,
+              "line": 449,
               "column": 9
             }
           },
@@ -9618,11 +10369,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 449,
+              "line": 451,
               "column": 8
             },
             "end": {
-              "line": 451,
+              "line": 453,
               "column": 9
             }
           },
@@ -9635,11 +10386,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 453,
+              "line": 455,
               "column": 8
             },
             "end": {
-              "line": 457,
+              "line": 459,
               "column": 9
             }
           },
@@ -9652,11 +10403,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 459,
+              "line": 461,
               "column": 8
             },
             "end": {
-              "line": 465,
+              "line": 467,
               "column": 9
             }
           },
@@ -9679,11 +10430,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 467,
+              "line": 469,
               "column": 8
             },
             "end": {
-              "line": 477,
+              "line": 479,
               "column": 9
             }
           },
@@ -9696,11 +10447,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 479,
+              "line": 481,
               "column": 8
             },
             "end": {
-              "line": 485,
+              "line": 487,
               "column": 9
             }
           },
@@ -9713,11 +10464,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 487,
+              "line": 489,
               "column": 8
             },
             "end": {
-              "line": 489,
+              "line": 491,
               "column": 9
             }
           },
@@ -9734,11 +10485,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 491,
+              "line": 493,
               "column": 8
             },
             "end": {
-              "line": 497,
+              "line": 499,
               "column": 9
             }
           },
@@ -9755,11 +10506,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 499,
+              "line": 501,
               "column": 8
             },
             "end": {
-              "line": 555,
+              "line": 557,
               "column": 9
             }
           },
@@ -9779,11 +10530,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 557,
+              "line": 559,
               "column": 8
             },
             "end": {
-              "line": 559,
+              "line": 561,
               "column": 9
             }
           },
@@ -9803,11 +10554,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 561,
+              "line": 563,
               "column": 8
             },
             "end": {
-              "line": 578,
+              "line": 580,
               "column": 9
             }
           },
@@ -9824,11 +10575,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 580,
+              "line": 582,
               "column": 8
             },
             "end": {
-              "line": 604,
+              "line": 606,
               "column": 9
             }
           },
@@ -9845,11 +10596,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 606,
+              "line": 608,
               "column": 8
             },
             "end": {
-              "line": 612,
+              "line": 614,
               "column": 9
             }
           },
@@ -9866,11 +10617,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 614,
+              "line": 616,
               "column": 8
             },
             "end": {
-              "line": 616,
+              "line": 618,
               "column": 9
             }
           },
@@ -9883,11 +10634,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 618,
+              "line": 620,
               "column": 8
             },
             "end": {
-              "line": 621,
+              "line": 623,
               "column": 9
             }
           },
@@ -9900,11 +10651,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 623,
+              "line": 625,
               "column": 8
             },
             "end": {
-              "line": 626,
+              "line": 628,
               "column": 9
             }
           },
@@ -9917,11 +10668,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 628,
+              "line": 630,
               "column": 8
             },
             "end": {
-              "line": 630,
+              "line": 632,
               "column": 9
             }
           },
@@ -9934,11 +10685,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 632,
+              "line": 634,
               "column": 8
             },
             "end": {
-              "line": 637,
+              "line": 639,
               "column": 9
             }
           },
@@ -9955,11 +10706,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 639,
+              "line": 641,
               "column": 8
             },
             "end": {
-              "line": 643,
+              "line": 645,
               "column": 9
             }
           },
@@ -9976,11 +10727,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 645,
+              "line": 647,
               "column": 8
             },
             "end": {
-              "line": 647,
+              "line": 649,
               "column": 9
             }
           },
@@ -9997,11 +10748,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 649,
+              "line": 651,
               "column": 8
             },
             "end": {
-              "line": 654,
+              "line": 656,
               "column": 9
             }
           },
@@ -10018,11 +10769,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 656,
+              "line": 658,
               "column": 8
             },
             "end": {
-              "line": 659,
+              "line": 661,
               "column": 9
             }
           },
@@ -10042,11 +10793,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 661,
+              "line": 663,
               "column": 8
             },
             "end": {
-              "line": 663,
+              "line": 665,
               "column": 9
             }
           },
@@ -10066,11 +10817,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 665,
+              "line": 667,
               "column": 8
             },
             "end": {
-              "line": 668,
+              "line": 670,
               "column": 9
             }
           },
@@ -10083,11 +10834,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 670,
+              "line": 672,
               "column": 8
             },
             "end": {
-              "line": 672,
+              "line": 674,
               "column": 9
             }
           },
@@ -10100,11 +10851,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 674,
+              "line": 676,
               "column": 8
             },
             "end": {
-              "line": 677,
+              "line": 679,
               "column": 9
             }
           },
@@ -10117,11 +10868,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 679,
+              "line": 681,
               "column": 8
             },
             "end": {
-              "line": 681,
+              "line": 683,
               "column": 9
             }
           },
@@ -10138,11 +10889,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 686,
+              "line": 688,
               "column": 8
             },
             "end": {
-              "line": 695,
+              "line": 697,
               "column": 9
             }
           },
@@ -10159,11 +10910,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 697,
+              "line": 699,
               "column": 8
             },
             "end": {
-              "line": 788,
+              "line": 790,
               "column": 9
             }
           },
@@ -10180,11 +10931,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 790,
+              "line": 792,
               "column": 8
             },
             "end": {
-              "line": 792,
+              "line": 794,
               "column": 9
             }
           },
@@ -10197,11 +10948,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 794,
+              "line": 796,
               "column": 8
             },
             "end": {
-              "line": 820,
+              "line": 822,
               "column": 9
             }
           },
@@ -10218,11 +10969,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 822,
+              "line": 824,
               "column": 8
             },
             "end": {
-              "line": 853,
+              "line": 855,
               "column": 9
             }
           },
@@ -10239,11 +10990,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 855,
+              "line": 857,
               "column": 8
             },
             "end": {
-              "line": 881,
+              "line": 883,
               "column": 9
             }
           },
@@ -10263,11 +11014,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 883,
+              "line": 885,
               "column": 8
             },
             "end": {
-              "line": 885,
+              "line": 887,
               "column": 9
             }
           },
@@ -10290,11 +11041,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 887,
+              "line": 889,
               "column": 8
             },
             "end": {
-              "line": 894,
+              "line": 896,
               "column": 9
             }
           },
@@ -10314,11 +11065,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 896,
+              "line": 898,
               "column": 8
             },
             "end": {
-              "line": 898,
+              "line": 900,
               "column": 9
             }
           },
@@ -10335,15 +11086,15 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 231,
+          "line": 233,
           "column": 6
         },
         "end": {
-          "line": 899,
+          "line": 901,
           "column": 7
         }
       },
-      "privacy": "public",
+      "privacy": "private",
       "superclass": "HTMLElement",
       "name": "DatePickerOverlayElement",
       "attributes": [
@@ -10352,11 +11103,11 @@
           "description": "The value for this element.",
           "sourceRange": {
             "start": {
-              "line": 242,
+              "line": 244,
               "column": 12
             },
             "end": {
-              "line": 245,
+              "line": 247,
               "column": 13
             }
           },
@@ -10368,11 +11119,11 @@
           "description": "Date value which is focused using keyboard.",
           "sourceRange": {
             "start": {
-              "line": 250,
+              "line": 252,
               "column": 12
             },
             "end": {
-              "line": 254,
+              "line": 256,
               "column": 13
             }
           },
@@ -10384,11 +11135,11 @@
           "description": "Date which should be visible when there is no value selected.",
           "sourceRange": {
             "start": {
-              "line": 261,
+              "line": 263,
               "column": 12
             },
             "end": {
-              "line": 264,
+              "line": 266,
               "column": 13
             }
           },
@@ -10400,11 +11151,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 282,
+              "line": 284,
               "column": 12
             },
             "end": {
-              "line": 284,
+              "line": 286,
               "column": 13
             }
           },
@@ -10416,11 +11167,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 286,
+              "line": 288,
               "column": 12
             },
             "end": {
-              "line": 288,
+              "line": 290,
               "column": 13
             }
           },
@@ -10432,11 +11183,11 @@
           "description": "The earliest date that can be selected. All earlier dates will be disabled.",
           "sourceRange": {
             "start": {
-              "line": 297,
+              "line": 299,
               "column": 12
             },
             "end": {
-              "line": 297,
+              "line": 299,
               "column": 25
             }
           },
@@ -10448,11 +11199,11 @@
           "description": "The latest date that can be selected. All later dates will be disabled.",
           "sourceRange": {
             "start": {
-              "line": 302,
+              "line": 304,
               "column": 12
             },
             "end": {
-              "line": 302,
+              "line": 304,
               "column": 25
             }
           },
@@ -10464,11 +11215,11 @@
           "description": "Input label",
           "sourceRange": {
             "start": {
-              "line": 309,
+              "line": 311,
               "column": 12
             },
             "end": {
-              "line": 309,
+              "line": 311,
               "column": 25
             }
           },

--- a/vaadin-date-picker-mixin.html
+++ b/vaadin-date-picker-mixin.html
@@ -62,6 +62,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Indicates whether this date picker has a value.
+         * @private
          */
         hasValue: {
           type: Boolean,
@@ -593,6 +594,7 @@ This program is available under Apache License Version 2.0, available at https:/
     /**
      * Returns true if `value` is valid, and sets the `invalid` flag appropriatelly.
      *
+     * @param {string} value Value to validate. Optional, defaults to user's input value.
      * @return {boolean} True if the value is valid and sets the `invalid` flag appropriatelly
      */
     validate(value) {
@@ -604,6 +606,9 @@ This program is available under Apache License Version 2.0, available at https:/
      * Returns true if the current input value satisfies all constraints (if any)
      *
      * Override the `checkValidity` method for custom validations.
+     *
+     * @param {string} value Value to validate. Optional, defaults to the selected date.
+     * @return {boolean} True if the value is valid
      */
     checkValidity(value) {
       var inputValid = !value || (this._selectedDate && value === this.i18n.formatDate(this._selectedDate));

--- a/vaadin-date-picker-overlay.html
+++ b/vaadin-date-picker-overlay.html
@@ -228,6 +228,9 @@ This program is available under Apache License Version 2.0, available at https:/
   </template>
   <script>
     {
+      /**
+       * @private
+       */
       class DatePickerOverlayElement extends Vaadin.ThemableMixin(Polymer.GestureEventListeners(Polymer.Element)) {
 
         static get is() {

--- a/vaadin-infinite-scroller.html
+++ b/vaadin-infinite-scroller.html
@@ -61,7 +61,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <script>
   {
-
+    /**
+     * @private
+     */
     class InfiniteScrollerElement extends Polymer.Element {
 
       static get is() {

--- a/vaadin-month-calendar.html
+++ b/vaadin-month-calendar.html
@@ -90,6 +90,9 @@ This program is available under Apache License Version 2.0, available at https:/
   </template>
   <script>
     {
+      /**
+       * @private
+       */
       class MonthCalendarElement extends Vaadin.ThemableMixin(Polymer.GestureEventListeners(Polymer.Element)) {
 
         static get is() {


### PR DESCRIPTION
Fixes #457

List of changes: 
- `hasValue` mark as `@private` 
- Parameter `value` was documented in `validate` method
- Parameter value and return boolean were documented in `checkValidity` method
- `DatePickerOverlayElement` marked as `@private`
- `InfiniteScrollerElement` marked as `@private`
- `MonthCalendarElement` marked as `@private`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/455)
<!-- Reviewable:end -->