### PR TITLE
Don't refocus on datepicker after blurring.

### DIFF
--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -97,6 +97,26 @@
         });
       }
 
+      it('should not focus when blurred', done => {
+        const input = datepicker._nativeInput;
+        datepicker.value = '2000-01-01';
+        input.focus();
+
+        datepicker.addEventListener('iron-overlay-opened', () => {
+          const input = document.createElement('input');
+          document.body.appendChild(input);
+          input.focus();
+          input.click();
+          document.body.removeChild(input);
+        });
+
+        datepicker.addEventListener('iron-overlay-closed', () => {
+          expect(input.getRootNode().activeElement).to.not.equal(input);
+          done();
+        });
+        datepicker.open();
+      });
+
       describe('Sizing', () => {
 
         beforeEach(() => {

--- a/vaadin-date-picker-mixin.html
+++ b/vaadin-date-picker-mixin.html
@@ -580,10 +580,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       this._ignoreFocusedDateChange = false;
 
-      if (this._nativeInput && this._nativeInput.selectionStart) {
-        this._nativeInput.selectionStart = this._nativeInput.selectionEnd;
-      }
-
       this.validate();
     }
 


### PR DESCRIPTION
Fixes #417

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/472)
<!-- Reviewable:end -->
