### PR TITLE
Implement control-state

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
     "polymer": "^2.0",
     "vaadin-button": "^1.0.0",
     "vaadin-text-field": "^1.0.0",
-    "vaadin-themable-mixin": "^1.1.0"
+    "vaadin-themable-mixin": "^1.1.0",
+    "vaadin-control-state-mixin": "^1.1.7"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/demo/date-picker-basic-demos.html
+++ b/demo/date-picker-basic-demos.html
@@ -15,6 +15,15 @@
       </template>
     </vaadin-demo-snippet>
 
+    <h3>TabIndex</h3>
+    <vaadin-demo-snippet id='date-picker-basic-demos-label-attribute'>
+      <template preserve-content>
+        <vaadin-date-picker tabindex="4" placeholder="TabIndex 4"></vaadin-date-picker>
+        <vaadin-date-picker tabindex="3" placeholder="TabIndex 3"></vaadin-date-picker>
+        <vaadin-date-picker tabindex="2" placeholder="TabIndex 2 disabled" disabled></vaadin-date-picker>
+        <vaadin-date-picker tabindex="1" placeholder="TabIndex 1"></vaadin-date-picker>
+      </template>
+    </vaadin-demo-snippet>
 
     <h3>Label attribute</h3>
     <vaadin-demo-snippet id='date-picker-basic-demos-label-attribute'>

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -496,6 +496,19 @@
             });
           });
 
+          it('should keep focused attribute in focusElement when the focus moves to the overlay', done => {
+            open(datepicker, () => {
+              MockInteractions.tap(datepicker.$.overlay);
+              datepicker.focusElement.blur();
+              expect(datepicker.focusElement.focused).to.be.false;
+
+              MockInteractions.focus(datepicker.$.overlay);
+              expect(datepicker.focused).to.be.true;
+              expect(datepicker.focusElement.focused).to.be.true;
+              done();
+            });
+          });
+
           it('should not reveal the focused date on tap', done => {
             open(datepicker, () => {
               var spy = sinon.spy(datepicker.$.overlay, 'revealDate');

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -9,6 +9,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../iron-dropdown/iron-dropdown.html">
 <link rel="import" href="../iron-media-query/iron-media-query.html">
 <link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
+<link rel="import" href="../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 <link rel="import" href="vaadin-date-picker-overlay.html">
 <link rel="import" href="vaadin-date-picker-mixin.html">
 <link rel="import" href="vaadin-date-picker-helper.html">
@@ -178,7 +179,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * @mixes Polymer.GestureEventListeners
        * @demo demo/index.html
        */
-      class DatePickerElement extends Vaadin.ThemableMixin(Vaadin.DatePickerMixin(Polymer.GestureEventListeners(Polymer.Element))) {
+      class DatePickerElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Vaadin.DatePickerMixin(Polymer.GestureEventListeners(Polymer.Element)))) {
 
         static get is() {
           return 'vaadin-date-picker';
@@ -271,6 +272,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _getAriaExpanded(opened) {
           return Boolean(opened).toString();
+        }
+
+        /**
+         * Focussable element used by vaadin-control-state-mixin
+         */
+        get focusElement() {
+          return this._input() || this;
         }
       }
 

--- a/vaadin-date-picker.html
+++ b/vaadin-date-picker.html
@@ -179,7 +179,10 @@ This program is available under Apache License Version 2.0, available at https:/
        * @mixes Polymer.GestureEventListeners
        * @demo demo/index.html
        */
-      class DatePickerElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Vaadin.DatePickerMixin(Polymer.GestureEventListeners(Polymer.Element)))) {
+      class DatePickerElement extends
+        Vaadin.ControlStateMixin(
+          Vaadin.ThemableMixin(
+            Vaadin.DatePickerMixin(Polymer.GestureEventListeners(Polymer.Element)))) {
 
         static get is() {
           return 'vaadin-date-picker';
@@ -244,6 +247,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
           // In order to have synchronized invalid property, we need to use the same validate logic.
           Polymer.RenderStatus.afterNextRender(this, () => this._inputElement.validate = () => {});
+
+          // Keep focus attribute in focusElement for styling
+          this.$.overlay.addEventListener('focus', () => this.focusElement._setFocused(true));
         }
 
         _clear(e) {


### PR DESCRIPTION
Fixes #477 #476 #429 

Additionally Keep input focused styling when overlay takes the focus to align with other elements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/478)
<!-- Reviewable:end -->
