### PR TITLE
Removing years-visible attribute in disconnectedCallback

### DIFF
--- a/src/vaadin-date-picker-overlay-content.html
+++ b/src/vaadin-date-picker-overlay-content.html
@@ -331,7 +331,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         connectedCallback() {
           super.connectedCallback();
-          this._translateX = this._yearScrollerWidth;
+          this._closeYearScroller();
           this._toggleAnimateClass(true);
           Polymer.Gestures.setTouchAction(this.$.scrollers, 'pan-y');
           Polymer.IronA11yAnnouncer.requestAvailability();


### PR DESCRIPTION
Fixes #491 

Removing `years-visible` attribute in `disconnectedCallback` so it will be removed before opening the overlay and after closing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/493)
<!-- Reviewable:end -->
