### PR TITLE
Update Valo theme

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "vaadin-themable-mixin": "^1.1.0",
     "vaadin-control-state-mixin": "^2.0.0",
     "vaadin-overlay": "^2.0.0",
-    "vaadin-valo-theme": "^2.0.0",
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.0.1"
   },
   "devDependencies": {

--- a/demo/date-picker-advanced-demos.html
+++ b/demo/date-picker-advanced-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="date-picker-advanced-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
@@ -9,7 +9,7 @@
 
 
     <h3>Localizing</h3>
-    <vaadin-demo-snippet id='date-picker-advanced-demos-localizing'>
+    <vaadin-demo-snippet id="date-picker-advanced-demos-localizing">
       <template preserve-content>
         <vaadin-date-picker label="Syntymäpäivä" id="finnish" value="1980-08-14">
         </vaadin-date-picker>
@@ -63,7 +63,7 @@
     <h3>Custom Validator</h3>
     <p>Extend <code>Vaadin.DatePickerElement</code> to create your own custom element,
        then override the <code>checkValidity(value)</code> method to validate the input.
-    <vaadin-demo-snippet id='date-picker-advanced-demos-custom-validator'>
+    <vaadin-demo-snippet id="date-picker-advanced-demos-custom-validator">
       <template preserve-content>
         <vaadin-date-picker-current-year></vaadin-date-picker-current-year>
 
@@ -83,7 +83,7 @@
 
 
     <h3>Custom Inputs</h3>
-    <vaadin-demo-snippet id='date-picker-advanced-demos-custom-inputs'>
+    <vaadin-demo-snippet id="date-picker-advanced-demos-custom-inputs">
       <template preserve-content>
         <style is="custom-style">
           .my-input1 input {
@@ -102,7 +102,7 @@
       </template>
     </vaadin-demo-snippet>
 
-    <vaadin-demo-snippet id='date-picker-advanced-demos-custom-inputs'>
+    <vaadin-demo-snippet id="date-picker-advanced-demos-custom-inputs">
       <template preserve-content>
         <style is="custom-style">
           .my-input2 input {
@@ -124,7 +124,6 @@
       </template>
     </vaadin-demo-snippet>
 
-  </div>
   </template>
   <script>
     class DatePickerAdvancedDemos extends DemoReadyEventEmitter(DatePickerDemo(Polymer.Element)) {

--- a/demo/date-picker-basic-demos.html
+++ b/demo/date-picker-basic-demos.html
@@ -1,32 +1,22 @@
 <dom-module id="date-picker-basic-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
-
     </style>
 
 
     <h3>Plain date picker</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-plain-date-picker'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-plain-date-picker">
       <template preserve-content>
         <vaadin-date-picker></vaadin-date-picker>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>TabIndex</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-label-attribute'>
-      <template preserve-content>
-        <vaadin-date-picker tabindex="4" placeholder="TabIndex 4"></vaadin-date-picker>
-        <vaadin-date-picker tabindex="3" placeholder="TabIndex 3"></vaadin-date-picker>
-        <vaadin-date-picker tabindex="2" placeholder="TabIndex 2 disabled" disabled></vaadin-date-picker>
-        <vaadin-date-picker tabindex="1" placeholder="TabIndex 1"></vaadin-date-picker>
-      </template>
-    </vaadin-demo-snippet>
 
     <h3>Label attribute</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-label-attribute'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-label-attribute">
       <template preserve-content>
         <vaadin-date-picker label="Pick a date">
         </vaadin-date-picker>
@@ -35,7 +25,7 @@
 
 
     <h3>Placeholder attribute</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-placeholder-attribute'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-placeholder-attribute">
       <template preserve-content>
         <vaadin-date-picker placeholder="Pick a date">
         </vaadin-date-picker>
@@ -44,7 +34,7 @@
 
 
     <h3>Label and placeholder attributes together</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-label-and-placeholder-attributes-together'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-label-and-placeholder-attributes-together">
       <template preserve-content>
         <vaadin-date-picker label="Birthday" placeholder="Pick a date">
         </vaadin-date-picker>
@@ -53,7 +43,7 @@
 
 
     <h3>Pre-selected value</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-pre-selected-value'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-pre-selected-value">
       <template preserve-content>
         <vaadin-date-picker label="Birthday" value="1980-08-14">
         </vaadin-date-picker>
@@ -62,7 +52,7 @@
 
 
     <h3>Disabled and readonly</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-disabled-and-readonly'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-disabled-and-readonly">
       <template preserve-content>
         <vaadin-date-picker disabled label="Disabled input" value="1980-08-14"></vaadin-date-picker>
         <vaadin-date-picker readonly label="Readonly input" value="1980-08-14"></vaadin-date-picker>
@@ -71,7 +61,7 @@
 
 
     <h3>Initial position</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-initial-position'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-initial-position">
       <template preserve-content>
         <vaadin-date-picker label="Birthday" initial-position="1980-01-01">
         </vaadin-date-picker>
@@ -80,7 +70,7 @@
 
 
     <h3>Min and max dates</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-min-and-max-dates'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-min-and-max-dates">
       <template preserve-content>
         <vaadin-date-picker label="June 2017" min="2017-06-01" max="2017-06-30" initial-position="2017-06-01">
         </vaadin-date-picker>
@@ -89,7 +79,7 @@
 
 
     <h3>Using as a Form Field</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-using-as-a-form-field'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-using-as-a-form-field">
       <template preserve-content>
         <iron-form>
           <form method="post">
@@ -118,9 +108,9 @@
 
 
     <h3>Date picker with week numbers</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-date-picker-with-week-numbers'>
+    <p>Week numbers are only supported for locales that start the week on Monday.</p>
+    <vaadin-demo-snippet id="date-picker-basic-demos-date-picker-with-week-numbers">
       <template preserve-content>
-        <p>Week numbers are only supported for locales that start the week on Monday.</p>
         <vaadin-date-picker id="weeks" show-week-numbers></vaadin-date-picker>
         <script>
           window.addDemoReadyListener('#date-picker-basic-demos-date-picker-with-week-numbers', function(document) {
@@ -136,7 +126,7 @@
 
 
     <h3>Keyboard input</h3>
-    <vaadin-demo-snippet id='date-picker-basic-demos-keyboard-input'>
+    <vaadin-demo-snippet id="date-picker-basic-demos-keyboard-input">
       <template preserve-content>
         <!--
         Using a 3rd party library to parse dates from the input text.
@@ -177,7 +167,7 @@
         </script>
       </template>
     </vaadin-demo-snippet>
-  </div>
+
   </template>
   <script>
     class DatePickerBasicDemos extends DemoReadyEventEmitter(DatePickerDemo(Polymer.Element)) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,11 +6,9 @@
   <title>vaadin-date-picker Examples</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <style>
-    body {
-      font-family: sans-serif;
-    }
-  </style>
+  <custom-style>
+    <style include="vaadin-component-demo-shared-styles"></style>
+  </custom-style>
 </head>
 
 <body>

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -21,7 +21,6 @@ This program is available under Apache License Version 2.0, available at https:/
     <style>
       :host {
         display: inline-block;
-        width: 175px;
       }
 
       :host([hidden]) {
@@ -33,8 +32,8 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       [part="text-field"] {
-        min-width: 100%;
-        max-width: 100%;
+        width: 100%;
+        min-width: 0;
       }
 
       [part="clear-button"],
@@ -51,9 +50,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       :host([disabled]) [part="clear-button"],
-      :host([disabled]) [part="toggle-button"],
       :host([readonly]) [part="clear-button"],
-      :host([readonly]) [part="toggle-button"],
       :host(:not([has-value])) [part="clear-button"] {
         display: none;
       }

--- a/test/basic.html
+++ b/test/basic.html
@@ -537,8 +537,8 @@
           expect(datepicker.$.overlay.opened).not.to.be.ok;
         });
 
-        it('calendar icon should be hidden', () => {
-          expect(toggleButton.clientHeight).to.equal(0);
+        it('calendar icon should not be hidden', () => {
+          expect(toggleButton.clientHeight).not.to.equal(0);
         });
 
         it('clear icon should be hidden', () => {
@@ -644,11 +644,11 @@
       });
 
       describe('Inside flexbox', () => {
-        it('date-picker should have width 175px', () => {
+        it('date-picker should stretch to fit the column flex container', () => {
           const container = fixture('datepicker-in-flexbox');
           const flexDatePicker = container.querySelector('vaadin-date-picker');
           expect(window.getComputedStyle(container).width).to.eql('500px');
-          expect(window.getComputedStyle(flexDatePicker).width).to.eql('175px');
+          expect(window.getComputedStyle(flexDatePicker).width).to.eql('500px');
         });
       });
     });

--- a/theme/valo/vaadin-date-picker-overlay-content.html
+++ b/theme/valo/vaadin-date-picker-overlay-content.html
@@ -1,10 +1,9 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
-<link rel="import" href="../../../vaadin-valo-theme/typography.html">
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/typography.html">
 
-<link rel="import" href="../../../vaadin-overlay/theme/valo/vaadin-overlay.html">
 <link rel="import" href="../../../vaadin-button/theme/valo/vaadin-button.html">
 
 <dom-module id="valo-date-picker-overlay-content" theme-for="vaadin-date-picker-overlay-content">
@@ -12,9 +11,7 @@
     <style>
       :host {
         position: relative;
-
-        max-height: calc(var(--valo-size-m) * 14);
-
+        background-color: transparent;
         /* Background for the year scroller, placed here as we are using a mask image on the actual years part */
         background-image: linear-gradient(var(--valo-tint-5pct), var(--valo-tint-5pct)), linear-gradient(var(--valo-shade-5pct), var(--valo-shade-5pct));
         background-size: calc(100% - 57px) 100%, 57px 100%;
@@ -27,26 +24,11 @@
       [part="months"] {
         /* TODO this property should support calc or measure the height from the DOM */
         /* --vaadin-infinite-scroller-item-height: calc(var(--valo-size-l) * 6 + var(--valo-font-size-l) + var(--valo-space-m) + var(--valo-font-size-xs) + var(--valo-space-s) + var(--valo-size-s)); */
-        --vaadin-infinite-scroller-item-height: 301px;
+        --vaadin-infinite-scroller-item-height: 19rem;
         -webkit-mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
         mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
         position: relative;
         margin-right: 57px;
-      }
-
-      @media (pointer: coarse) {
-        :host {
-          max-height: calc(var(--valo-size-l) * 14);
-        }
-
-        [part="months"] {
-          /* --vaadin-infinite-scroller-item-height: calc(var(--valo-size-m) * 6 + var(--valo-font-size-l) + var(--valo-space-m) + var(--valo-font-size-xs) + var(--valo-space-s) + var(--valo-size-s)); */
-          --vaadin-infinite-scroller-item-height: 349px;
-        }
-      }
-
-      [part="month"][disabled] {
-        opacity: 0.3;
       }
 
       /* Year scroller */
@@ -125,8 +107,8 @@
       [part="toolbar"] {
         padding: var(--valo-space-wide-s);
         box-shadow: 0 -1px 0 0 var(--valo-contrast-10pct);
-        margin-right: 57px;
         border-bottom-left-radius: var(--valo-border-radius);
+        margin-right: 57px;
       }
 
       @supports (mask-image: linear-gradient(#000, #000)) or (-webkit-mask-image: linear-gradient(#000, #000)) {
@@ -146,33 +128,21 @@
         margin: 0 calc(var(--valo-space-s) * -1);
       }
 
-      [part="toolbar"] [part$="button"]:not([focused]) {
-        box-shadow: none;
-      }
-
-      [part="toolbar"] [part$="button"][active] {
-        color: var(--valo-body-text-color);
-      }
-
-      [part="toolbar"] [part$="button"][active]::before {
-        display: none;
-      }
-
       /* Narrow viewport mode (fullscreen) */
 
-      :host([fullscreen]) {
-        max-height: none;
-        border-radius: 0;
+      :host([fullscreen]) [part="toolbar"] {
+        order: -1;
+        background-color: var(--valo-base-color);
       }
 
-      [part="overlay-header"] {
-        padding: var(--valo-space-s);
-        margin-right: 57px;
-      }
-
-      /* TODO why is there a forced padding-bottom in the core styles */
-      [part="overlay-header"]:not([desktop]) {
-        padding: 0;
+      :host([fullscreen]) [part="overlay-header"] {
+        order: -2;
+        height: var(--valo-size-m);
+        padding: var(--valo-space-wide-s);
+        position: absolute;
+        left: 0;
+        right: 0;
+        justify-content: center;
       }
 
       :host([fullscreen]) [part="toggle-button"],
@@ -184,25 +154,23 @@
       /* Very narrow screen (year scroller initially hidden) */
 
       [part="years-toggle-button"] {
-        top: 0;
-        right: 0;
-        bottom: auto;
-        padding: var(--valo-space-s);
+        position: relative;
+        right: auto;
+        display: flex;
+        align-items: center;
+        height: var(--valo-size-s);
+        padding: 0 0.5em;
+        border-radius: var(--valo-border-radius);
+        z-index: 3;
         color: var(--valo-primary-text-color);
-        text-align: right;
-        flex: 1;
+        font-weight: 500;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
 
-      [part="years-toggle-button"]::after {
-        content: "";
-        position: absolute;
-        z-index: -1;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        background-color: var(--valo-base-color);
-        filter: blur(8px);
+      :host([years-visible]) [part="years-toggle-button"] {
+        background-color: var(--valo-primary-color);
+        color: var(--valo-primary-contrast-color);
       }
 
       [part="years-toggle-button"]::before {
@@ -219,8 +187,7 @@
           background-color: var(--valo-shade-5pct);
         }
 
-        [part="overlay-header"],
-        :host(:not([years-visible])) [part="toolbar"],
+        [part="toolbar"],
         [part="months"] {
           margin-right: 0;
         }

--- a/theme/valo/vaadin-date-picker-overlay.html
+++ b/theme/valo/vaadin-date-picker-overlay.html
@@ -1,10 +1,49 @@
-<link rel="import" href="../../../vaadin-overlay/theme/valo/vaadin-overlay.html">
+<link rel="import" href="../../../vaadin-valo-styles/mixins/overlay.html">
 
 <dom-module id="valo-date-picker-overlay" theme-for="vaadin-date-picker-overlay">
   <template>
-    <style>
-      [part="overlay"] {
-        padding: 0; /* Override Valo theme for <vaadin-overlay>’s default padding */
+    <style include="valo-overlay">
+      [part="overlay"][part="overlay"] {
+        width: calc(var(--valo-size-m) * 10);
+        max-height: calc(var(--valo-size-m) * 14);
+        overflow: hidden;
+        animation: 0.2s vaadin-menu-overlay-enter;
+        overflow: hidden;
+        height: 100%;
+      }
+
+      @keyframes vaadin-menu-overlay-enter {
+        0% {
+          opacity: 0;
+          transform: translateY(-4px);
+        }
+      }
+
+      :host([show-week-numbers]) [part="overlay"]:not([fullscreen]) {
+        width: calc(var(--valo-size-m) * 11);
+      }
+
+      [part="content"] {
+        padding: 0;
+        height: 100%;
+      }
+
+      :host([fullscreen]) [part~="overlay"][part~="overlay"] {
+        width: 100vw;
+        height: 70vh;
+        flex: none;
+        animation: 0.15s vaadin-date-picker-mobile-overlay-enter cubic-bezier(.215, .61, .355, 1);
+        border-radius: 0;
+      }
+
+      @keyframes vaadin-date-picker-mobile-overlay-enter {
+        0% {
+          transform: translateY(150%);
+        }
+      }
+
+      :host([fullscreen]) [part~="backdrop"] {
+        display: block;
       }
     </style>
   </template>

--- a/theme/valo/vaadin-date-picker.html
+++ b/theme/valo/vaadin-date-picker.html
@@ -1,9 +1,11 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/font-icons.html">
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+
+<link rel="import" href="../../../vaadin-valo-styles/mixins/field-button.html">
 
 <link rel="import" href="../../../vaadin-text-field/theme/valo/vaadin-text-field.html">
-<link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
 
 <link rel="import" href="vaadin-date-picker-overlay.html">
 <link rel="import" href="vaadin-date-picker-overlay-content.html">
@@ -11,72 +13,14 @@
 
 <dom-module id="valo-date-picker" theme-for="vaadin-date-picker">
   <template>
-    <style>
-      :host {
-        -webkit-tap-highlight-color: transparent;
-      }
-
-      :host([label]) {
-        margin-top: var(--valo-space-m);
-        vertical-align: var(---vaadin-text-field-vertical-align-offset);
-      }
-
-      [part="text-field"] {
-        display: block;
-        max-width: 100%;
-      }
-
-      [part$="button"] {
-        width: 24px;
-        height: 24px;
-        line-height: 24px;
-        font-size: 24px;
-        text-align: center;
-        color: var(--valo-contrast-40pct);
-        transition: 0.2s color;
-        cursor: default;
-      }
-
-      [part$="button"]:hover {
-        color: var(--valo-contrast-70pct);
-      }
-
-      [part$="button"]::before {
-        font-family: "valo-icons";
-      }
-
-      [part="toggle-button"] {
-        order: -1;
-      }
-
+    <style include="valo-field-button">
       [part="toggle-button"]::before {
-        content: "\e908";
+        content: var(--valo-icons-calendar);
       }
 
       [part="clear-button"]::before {
-        content: "\e907";
+        content: var(--valo-icons-cross);
       }
-
-      :host([disabled]) [part="toggle-button"] {
-        display: block;
-        color: var(--valo-contrast-20pct);
-      }
-
-      /* Overlay width */
-
-      [part="overlay"] {
-        width: calc(var(--valo-size-m) * 10);
-      }
-
-      :host([show-week-numbers]) [part="overlay"]:not([fullscreen]) {
-        width: calc(var(--valo-size-m) * 11);
-      }
-
-      [part="overlay"][fullscreen] {
-        width: 100vw;
-        height: 100vh;
-      }
-
     </style>
   </template>
 </dom-module>

--- a/theme/valo/vaadin-month-calendar.html
+++ b/theme/valo/vaadin-month-calendar.html
@@ -1,8 +1,8 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
-<link rel="import" href="../../../vaadin-valo-theme/typography.html">
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/typography.html">
 
 <dom-module id="valo-month-calendar" theme-for="vaadin-month-calendar">
   <template>
@@ -15,6 +15,7 @@
         font-size: var(--valo-font-size-m);
         color: var(--valo-body-text-color);
         text-align: center;
+        padding: 0 var(--valo-space-xs);
         /* Make the currently focused month be roughly in the center of the overlay */
         /* TODO expose the overlay max-height as a custom property, so it can be used in calc's */
         /* TODO this doesn’t work nicely with the infinite scroller buffers, as sometimes one buffer
@@ -22,22 +23,6 @@
          * offset for now, and compensating it in the scroll item height */
         /* transform: translateY(calc(var(--valo-size-m) * 2)); */
         transform: translateY(var(--valo-size-s));
-        /* Make equal horizontal spacing between dates and element edges */
-        padding: 0 calc(100% / 8 / 2);
-      }
-
-      :host([week-numbers]) {
-        /* Make equal horizontal spacing between dates and element edges */
-        /* In case when week numbers are visible, there is one more gap */
-        padding: 0 calc(100% / 9 / 2);
-      }
-
-      /* Disabled state */
-
-      :host([disabled]),
-      [part="date"][disabled] {
-        color: var(--valo-disabled-text-color);
-        cursor: default;
       }
 
       /* Month header */
@@ -68,7 +53,6 @@
       [part="weekday"]:empty,
       [part="week-numbers"] {
         width: var(--valo-size-s);
-        padding-left: var(--valo-space-xs);
       }
 
       /* Date and week number cells */
@@ -79,14 +63,6 @@
         height: var(--valo-size-m);
         line-height: var(--valo-size-m);
         position: relative;
-      }
-
-      @media (pointer: coarse) {
-        [part="date"],
-        [part="week-number"] {
-          height: var(--valo-size-l);
-          line-height: var(--valo-size-l);
-        }
       }
 
       [part="date"]:not(:empty):not([disabled]) {
@@ -149,6 +125,13 @@
         [part="date"][selected]::before {
           content: "";
         }
+      }
+
+      /* Disabled */
+
+      :host([disabled]) * {
+        color: var(--valo-disabled-text-color) !important;
+        cursor: default;
       }
     </style>
   </template>


### PR DESCRIPTION
The “fullscreen” mode is less fullscreen now, only taking 70vh, and sliding up from the bottom of the viewport and having a backdrop, like context and dropdown menus.

Updated tests to comply with the new specs (stretch in a flex container, show toggle button always by default).

Small fixes to the demos as well (needs a larger restructuring at some point, though).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/494)
<!-- Reviewable:end -->
