### PR TITLE
Restore focus ring if firstly was focused with Tab

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -298,7 +298,8 @@ This program is available under Apache License Version 2.0, available at https:/
         '_validateInput(_selectedDate, _minDate, _maxDate)',
         '_selectedDateChanged(_selectedDate, i18n.formatDate)',
         '_focusedDateChanged(_focusedDate, i18n.formatDate)',
-        '_announceFocusedDate(_focusedDate, opened, _ignoreAnnounce)'
+        '_announceFocusedDate(_focusedDate, opened, _ignoreAnnounce)',
+        '_openChanged(opened)'
       ];
     }
 
@@ -314,6 +315,12 @@ This program is available under Apache License Version 2.0, available at https:/
       this._overlayContent.addEventListener('focus-input', this._focusAndSelect.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
+    }
+
+    _openChanged(opened) {
+      if (opened) {
+        this._openedWithFocusRing = this.hasAttribute('focus-ring');
+      }
     }
 
     /**

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -319,7 +319,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _openChanged(opened) {
       if (opened) {
-        this._openedWithFocusRing = this.hasAttribute('focus-ring');
+        this._openedWithFocusRing = this.hasAttribute('focus-ring') || this.focusElement.hasAttribute('focus-ring');
       }
     }
 

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -298,8 +298,7 @@ This program is available under Apache License Version 2.0, available at https:/
         '_validateInput(_selectedDate, _minDate, _maxDate)',
         '_selectedDateChanged(_selectedDate, i18n.formatDate)',
         '_focusedDateChanged(_focusedDate, i18n.formatDate)',
-        '_announceFocusedDate(_focusedDate, opened, _ignoreAnnounce)',
-        '_openChanged(opened)'
+        '_announceFocusedDate(_focusedDate, opened, _ignoreAnnounce)'
       ];
     }
 
@@ -315,12 +314,6 @@ This program is available under Apache License Version 2.0, available at https:/
       this._overlayContent.addEventListener('focus-input', this._focusAndSelect.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
-    }
-
-    _openChanged(opened) {
-      if (opened) {
-        this._openedWithFocusRing = this.hasAttribute('focus-ring') || this.focusElement.hasAttribute('focus-ring');
-      }
     }
 
     /**
@@ -501,6 +494,8 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onOverlayOpened() {
+      this._openedWithFocusRing = this.hasAttribute('focus-ring') || (this.focusElement && this.focusElement.hasAttribute('focus-ring'));
+
       var parsedInitialPosition = this._parseDate(this.initialPosition);
 
       var initialPosition = this._selectedDate || this._overlayContent.initialPosition ||

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -258,6 +258,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _onVaadinOverlayClose(e) {
+          if (this._openedWithFocusRing) {
+            this.focusElement.setAttribute('focus-ring', '');
+          }
           if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().indexOf(this) !== -1) {
             e.preventDefault();
           }

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -258,7 +258,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _onVaadinOverlayClose(e) {
-          if (this._openedWithFocusRing) {
+          if (this._openedWithFocusRing && this.hasAttribute('focused')) {
             this.focusElement.setAttribute('focus-ring', '');
           }
           if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().indexOf(this) !== -1) {

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -260,6 +260,8 @@ This program is available under Apache License Version 2.0, available at https:/
         _onVaadinOverlayClose(e) {
           if (this._openedWithFocusRing && this.hasAttribute('focused')) {
             this.focusElement.setAttribute('focus-ring', '');
+          } else if (!this.hasAttribute('focused')){
+            this.focusElement.blur();
           }
           if (e.detail.sourceEvent && e.detail.sourceEvent.composedPath().indexOf(this) !== -1) {
             e.preventDefault();

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -143,6 +143,13 @@
         expect(datepicker.hasAttribute('focus-ring')).to.be.true;
       });
 
+      it('should remove attribute focus-ring if it was not initially set before opening', () => {
+        datepicker.opened = true;
+        datepicker.setAttribute('focus-ring', '');
+        datepicker.opened = false;
+        expect(datepicker.focusElement.hasAttribute('focus-ring')).to.be.false;
+      });
+
       it('should not close on clear-button down', () => {
         datepicker.open();
         datepicker.value = '2001-01-01';

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -136,6 +136,13 @@
         datepicker.open();
       });
 
+      it('should restore attribute focus-ring if it was initially set before opening', () => {
+        datepicker.setAttribute('focus-ring', '');
+        datepicker.opened = true;
+        datepicker.opened = false;
+        expect(datepicker.hasAttribute('focus-ring')).to.be.true;
+      });
+
       it('should not close on clear-button down', () => {
         datepicker.open();
         datepicker.value = '2001-01-01';


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/306

Restore `focus-ring` if component was firstly focused with <kbd>Tab</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/500)
<!-- Reviewable:end -->
