### PR TITLE
Refactor overlay styles to use lumo-menu-overlay

### DIFF
--- a/src/vaadin-date-picker-overlay-content.html
+++ b/src/vaadin-date-picker-overlay-content.html
@@ -526,7 +526,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           var duration = animate ? 300 : 0;
           var start = 0;
-          var initialPosition = this.$.monthScroller.position;
+          var initialPosition = Math.round(this.$.monthScroller.position);
 
           var smoothScroll = timestamp => {
             start = start || timestamp;

--- a/theme/lumo/vaadin-date-picker-overlay-content.html
+++ b/theme/lumo/vaadin-date-picker-overlay-content.html
@@ -22,7 +22,17 @@
       /* Month scroller */
 
       [part="months"] {
-        --vaadin-infinite-scroller-item-height: calc((var(--lumo-size-s) + var(--lumo-space-s)) * 6 + var(--lumo-font-size-l) + var(--lumo-space-m) + var(--lumo-font-size-xs) + var(--lumo-space-s) + var(--lumo-space-s));
+        /* Month calendar height:
+              header height + margin-bottom
+            + weekdays height + margin-bottom
+            + date cell heights
+            + small margin between month calendars
+        */
+        --vaadin-infinite-scroller-item-height: calc(
+            var(--lumo-font-size-l) + var(--lumo-space-m)
+          + var(--lumo-font-size-xs) + var(--lumo-space-s)
+          + var(--lumo-size-m) * 6
+          + var(--lumo-space-s));
         --vaadin-infinite-scroller-buffer-offset: 20%;
         -webkit-mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
         mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);

--- a/theme/lumo/vaadin-date-picker-overlay-content.html
+++ b/theme/lumo/vaadin-date-picker-overlay-content.html
@@ -22,8 +22,8 @@
       /* Month scroller */
 
       [part="months"] {
-        /* TODO this property should support calc or measure the height from the DOM. At the moment it doesn't take --lumo-size/space into account */
-        --vaadin-infinite-scroller-item-height: 19rem;
+        --vaadin-infinite-scroller-item-height: calc((var(--lumo-size-s) + var(--lumo-space-s)) * 6 + var(--lumo-font-size-l) + var(--lumo-space-m) + var(--lumo-font-size-xs) + var(--lumo-space-s) + var(--lumo-space-s));
+        --vaadin-infinite-scroller-buffer-offset: 20%;
         -webkit-mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
         mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
         position: relative;

--- a/theme/lumo/vaadin-date-picker-overlay-content.html
+++ b/theme/lumo/vaadin-date-picker-overlay-content.html
@@ -28,11 +28,13 @@
             + date cell heights
             + small margin between month calendars
         */
-        --vaadin-infinite-scroller-item-height: calc(
-            var(--lumo-font-size-l) + var(--lumo-space-m)
-          + var(--lumo-font-size-xs) + var(--lumo-space-s)
-          + var(--lumo-size-m) * 6
-          + var(--lumo-space-s));
+        --vaadin-infinite-scroller-item-height:
+          calc(
+              var(--lumo-font-size-l) + var(--lumo-space-m)
+            + var(--lumo-font-size-xs) + var(--lumo-space-s)
+            + var(--lumo-size-m) * 6
+            + var(--lumo-space-s)
+          );
         --vaadin-infinite-scroller-buffer-offset: 20%;
         -webkit-mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);
         mask-image: linear-gradient(transparent, #000 10%, #000 85%, transparent);

--- a/theme/lumo/vaadin-date-picker-overlay.html
+++ b/theme/lumo/vaadin-date-picker-overlay.html
@@ -6,7 +6,16 @@
   <template>
     <style include="lumo-menu-overlay">
       [part="overlay"] {
-        width: calc(var(--lumo-size-s) * 7 + var(--lumo-space-s) * 7 + var(--lumo-space-xs) * 2 + 57px);
+        /*
+        Width:
+            date cell widths
+          + month calendar side padding
+          + year scroller width
+        */
+        width: calc(
+            var(--lumo-size-m) * 7
+          + var(--lumo-space-xs) * 2
+          + 57px);
         height: 100%;
         max-height: calc(var(--lumo-size-m) * 14);
         overflow: hidden;

--- a/theme/lumo/vaadin-date-picker-overlay.html
+++ b/theme/lumo/vaadin-date-picker-overlay.html
@@ -1,61 +1,32 @@
 <link rel="import" href="../../../vaadin-lumo-styles/sizing.html">
 <link rel="import" href="../../../vaadin-lumo-styles/spacing.html">
-<link rel="import" href="../../../vaadin-lumo-styles/mixins/overlay.html">
+<link rel="import" href="../../../vaadin-lumo-styles/mixins/menu-overlay.html">
 
 <dom-module id="lumo-date-picker-overlay" theme-for="vaadin-date-picker-overlay">
   <template>
-    <style include="lumo-overlay">
+    <style include="lumo-menu-overlay">
       [part="overlay"] {
-        width: calc(var(--lumo-size-s) * 7 + var(--lumo-space-s) * 7 + 57px);
+        width: calc(var(--lumo-size-s) * 7 + var(--lumo-space-s) * 7 + var(--lumo-space-xs) * 2 + 57px);
+        height: 100%;
         max-height: calc(var(--lumo-size-m) * 14);
         overflow: hidden;
-        animation: 0.2s vaadin-menu-overlay-enter;
-        height: 100%;
         -webkit-tap-highlight-color: transparent;
-      }
-
-      @keyframes vaadin-menu-overlay-enter {
-        0% {
-          opacity: 0;
-          transform: translateY(-4px);
-        }
-      }
-
-      :host([show-week-numbers]) [part="overlay"]:not([fullscreen]) {
-        width: calc(var(--lumo-size-m) * 11);
       }
 
       [part="content"] {
         padding: 0;
         height: 100%;
+        overflow: hidden;
+        -webkit-mask-image: none;
+        mask-image: none;
       }
 
-      :host([fullscreen]) {
-        top: 0 !important;
-        right: 0 !important;
-        bottom: var(--vaadin-overlay-viewport-bottom, 0) !important;
-        left: 0 !important;
-        align-items: stretch;
-        justify-content: flex-end;
-      }
-
-      :host([fullscreen]) [part~="overlay"] {
-        max-height: initial;
-        width: 100vw;
-        height: 70vh;
-        flex: none;
-        animation: 0.15s vaadin-date-picker-mobile-overlay-enter cubic-bezier(.215, .61, .355, 1);
-        border-radius: 0;
-      }
-
-      @keyframes vaadin-date-picker-mobile-overlay-enter {
-        0% {
-          transform: translateY(150%);
+      @media (max-width: 420px), (max-height: 420px) {
+        [part="overlay"] {
+          width: 100vw;
+          height: 70vh;
+          max-height: 70vh;
         }
-      }
-
-      :host([fullscreen]) [part~="backdrop"] {
-        display: block;
       }
     </style>
   </template>

--- a/theme/lumo/vaadin-date-picker-overlay.html
+++ b/theme/lumo/vaadin-date-picker-overlay.html
@@ -12,10 +12,12 @@
           + month calendar side padding
           + year scroller width
         */
-        width: calc(
-            var(--lumo-size-m) * 7
-          + var(--lumo-space-xs) * 2
-          + 57px);
+        width:
+          calc(
+              var(--lumo-size-m) * 7
+            + var(--lumo-space-xs) * 2
+            + 57px
+          );
         height: 100%;
         max-height: calc(var(--lumo-size-m) * 14);
         overflow: hidden;

--- a/theme/lumo/vaadin-month-calendar.html
+++ b/theme/lumo/vaadin-month-calendar.html
@@ -17,12 +17,6 @@
         color: var(--lumo-body-text-color);
         text-align: center;
         padding: 0 var(--lumo-space-xs);
-        /* Make the currently focused month be roughly in the center of the overlay */
-        /* TODO this doesn’t work nicely with the infinite scroller buffers, as sometimes one buffer
-         * will overlap the other, and the user can’t click on a date to select it. Using smaller
-         * offset for now, and compensating it in the scroll item height */
-        /* transform: translateY(calc(var(--lumo-size-m) * 2)); */
-        transform: translateY(var(--lumo-size-s));
       }
 
       /* Month header */
@@ -123,7 +117,7 @@
       }
 
       @media (pointer: coarse) {
-        [part="date"]:hover::before,
+        [part="date"]:hover:not([selected])::before,
         [part="date"][focused]:not([selected])::before {
           display: none;
         }

--- a/theme/lumo/vaadin-month-calendar.html
+++ b/theme/lumo/vaadin-month-calendar.html
@@ -57,7 +57,7 @@
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        height: calc(var(--lumo-size-s) + var(--lumo-space-s));
+        height: var(--lumo-size-m);
         position: relative;
       }
 


### PR DESCRIPTION
Remove copy-paste code and use the `lumo-menu-overlay` mixin directly.

Use CSS media queries instead of the `fullscreen` property for the overlay behavior adjustments (consistent with the menu-overlay styles).

A couple of other small style fixes related to sizing and touch device styles.

Use `--vaadin-infinite-scroller-buffer-offset` instead of a transform to shift the first month in the scroller closer to the middle of the overlay.

Depends on https://github.com/vaadin/vaadin-lumo-styles/pull/9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/518)
<!-- Reviewable:end -->
