### PR TITLE
Remove animations from tests

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -7,6 +7,7 @@
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../vaadin-date-picker.html">
+  <link rel="import" href="not-animated-styles.html">
   <script src="common.js"></script>
 </head>
 

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -7,6 +7,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <link rel="import" href="../vaadin-date-picker.html">
+  <link rel="import" href="not-animated-styles.html">
   <script src="common.js"></script>
   <script>
     HTMLImports.whenReady(() => {

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -9,6 +9,7 @@
 
   <link rel="import" href="../../iron-form/iron-form.html">
   <link rel="import" href="../vaadin-date-picker.html">
+  <link rel="import" href="not-animated-styles.html">
 </head>
 
 <body>

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -9,6 +9,7 @@
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../vaadin-date-picker.html">
+  <link rel="import" href="not-animated-styles.html">
 </head>
 
 <body>

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -9,6 +9,7 @@
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../vaadin-date-picker.html">
+  <link rel="import" href="not-animated-styles.html">
 </head>
 
 <body>

--- a/test/not-animated-styles.html
+++ b/test/not-animated-styles.html
@@ -1,0 +1,12 @@
+<dom-module id="not-animated-date-picker-overlay" theme-for="vaadin-date-picker-overlay">
+  <template>
+    <style include="lumo-date-picker-overlay">
+      :host([opening]),
+      :host([closing]),
+      :host([opening]) [part="overlay"],
+      :host([closing]) [part="overlay"] {
+        animation: none !important;
+      }
+    </style>
+  </template>
+</dom-module>

--- a/test/wai-aria.html
+++ b/test/wai-aria.html
@@ -11,6 +11,7 @@
   <link rel="import" href="../src/vaadin-date-picker-overlay.html">
   <link rel="import" href="../src/vaadin-date-picker-overlay-content.html">
   <link rel="import" href="../src/vaadin-month-calendar.html">
+  <link rel="import" href="not-animated-styles.html">
   <script src="common.js"></script>
 </head>
 


### PR DESCRIPTION
In the upcoming `vaadin-overlay` release, the animations feature is to be introduced, which in conjunction with the default animation styles in latest Lumo (`lumo-menu-overlay-core`) cause random failures.

Related https://github.com/vaadin/vaadin-dropdown-menu/pull/110
Related https://github.com/vaadin/vaadin-combo-box/pull/632

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/526)
<!-- Reviewable:end -->
