### PR TITLE
Handle the 'close' event on the overlay content, not on date-picker

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -311,7 +311,7 @@ This program is available under Apache License Version 2.0, available at https:/
       Polymer.Gestures.addListener(this, 'tap', this.open);
       this.addEventListener('touchend', this._preventDefault.bind(this));
       this.addEventListener('keydown', this._onKeydown.bind(this));
-      this.addEventListener('close', this._close.bind(this));
+      this._overlayContent.addEventListener('close', this._close.bind(this));
       this._overlayContent.addEventListener('focus-input', this._focusAndSelect.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());


### PR DESCRIPTION
Fixes #541 

This fix is needed for https://github.com/vaadin/vaadin-overlay/pull/85 to pass, the broken build there: https://travis-ci.org/vaadin/vaadin-overlay/jobs/370538633

The test case is already presented in the codebase: https://github.com/vaadin/vaadin-date-picker/blob/master/test/overlay.html#L209-L214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/542)
<!-- Reviewable:end -->
