### PR TITLE
Format date to iso manually

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -394,9 +394,28 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _formatISO(date) {
-      return date instanceof Date ?
-        (new Date(date.getTime() - date.getTimezoneOffset() * 60000)).toISOString().split('T')[0] :
-        '';
+      if (!(date instanceof Date)) {
+        return '';
+      }
+
+      const pad = (num, fmt = '00') => (fmt + num).substr((fmt + num).length - fmt.length);
+
+      let yearSign = '';
+      let yearFmt = '0000';
+      let yearAbs = date.getFullYear();
+      if (yearAbs < 0) {
+        yearAbs = -yearAbs;
+        yearSign = '-';
+        yearFmt = '000000';
+      } else if (date.getFullYear() >= 10000) {
+        yearSign = '+';
+        yearFmt = '000000';
+      }
+
+      const year = yearSign + pad(yearAbs, yearFmt);
+      const month = pad(date.getMonth() + 1);
+      const day = pad(date.getDate());
+      return [year, month, day].join('-');
     }
 
     _openedChanged(opened) {

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -71,7 +71,7 @@
       it('should update position of the overlay after changing opened property', () => {
         datepicker.opened = true;
 
-        expect(input.getBoundingClientRect().bottom).to.equal(overlay.getBoundingClientRect().top);
+        expect(input.getBoundingClientRect().bottom).to.be.closeTo(overlay.getBoundingClientRect().top, 0.01);
       });
 
       if (document.createElement('div').style.webkitOverflowScrolling === '') {


### PR DESCRIPTION
Fixes #574 

Don't use the convenient `toISOString()` while formatting a date to ISO, but handle it manually. This way we'll skip the problematic UTC-conversion. Date picker operates in local time internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/576)
<!-- Reviewable:end -->
