### PR TITLE
Validate new value before triggering value-changed event

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -433,11 +433,13 @@ This program is available under Apache License Version 2.0, available at https:/
       if (this.__userInputOccurred) {
         this.__dispatchChange = true;
       }
+      const inputValue = selectedDate && formatDate(Vaadin.DatePickerHelper._extractDateParts(selectedDate));
+      this.validate(inputValue);
       this.value = this._formatISO(selectedDate);
       this.__userInputOccurred = false;
       this.__dispatchChange = false;
       this._focusedDate = selectedDate;
-      this._inputValue = selectedDate ? formatDate(Vaadin.DatePickerHelper._extractDateParts(selectedDate)) : '';
+      this._inputValue = selectedDate ? inputValue : '';
     }
 
     _focusedDateChanged(focusedDate, formatDate) {
@@ -629,8 +631,6 @@ This program is available under Apache License Version 2.0, available at https:/
       if (this._nativeInput && this._nativeInput.selectionStart) {
         this._nativeInput.selectionStart = this._nativeInput.selectionEnd;
       }
-      // reset invalid state on the underlying text field
-      this.invalid = false;
       this.validate();
     }
 
@@ -641,6 +641,8 @@ This program is available under Apache License Version 2.0, available at https:/
      * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
      */
     validate(value) {
+      // reset invalid state on the underlying text field
+      this.invalid = false;
       value = value !== undefined ? value : this._inputValue;
       return !(this.invalid = !this.checkValidity(value));
     }

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -153,6 +153,24 @@
         datepicker.close();
       });
 
+      it('should set proper validity by the time the value-changed event is fired', done => {
+        // Set invalid value.
+        inputValue('foo');
+        expect(datepicker.validate()).to.equal(false);
+
+        const spy = sinon.spy(datepicker, 'validate');
+
+        datepicker.addEventListener('value-changed', () => {
+          expect(spy).to.be.calledOnce;
+          expect(datepicker.invalid).to.equal(false);
+          done();
+        });
+
+        datepicker.open();
+        inputValue('01/01/2000');
+        datepicker.close();
+      });
+
       it('should display the error-message when invalid', () => {
         datepicker.invalid = true;
         datepicker.errorMessage = 'Not cool';


### PR DESCRIPTION
Fixes #586 

A better implementation of fix initially added in #492
This way we also make sure that both `2000-01-01` and `01/01/2000` formats pass the validation consistently, as the users might expect it to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/588)
<!-- Reviewable:end -->
