### PR TITLE
Fix Custom Validator demo

### DIFF
--- a/demo/date-picker-validation-demos.html
+++ b/demo/date-picker-validation-demos.html
@@ -50,7 +50,9 @@
                 return new Date(value).getFullYear() === currentYear;
               }
             }
-            customElements.define('vaadin-date-picker-current-year', DatePickerCurrentYearElement);
+            if (!customElements.get('vaadin-date-picker-current-year')) {
+              customElements.define('vaadin-date-picker-current-year', DatePickerCurrentYearElement);
+            }
           });
         </script>
       </template>


### PR DESCRIPTION
If you navigate Basic demos -> Advanced -> Basic -> Advanced you get the following error to your console:
<img width="487" alt="screen shot 2018-06-10 at 12 02 21" src="https://user-images.githubusercontent.com/8615573/41200172-4693d6dc-6ca8-11e8-8791-599e2cb43901.png">

`vaadin-date-picker-current-year` custom element is being registered again and this breaks the custom validator demo as well.

The same as #569

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/590)
<!-- Reviewable:end -->
