### PR TITLE
Cleanup unused code and unnecessary DOM measurements

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -11,6 +11,9 @@ This program is available under Apache License Version 2.0, available at https:/
 <script>
   window.Vaadin = window.Vaadin || {};
 
+  // Checking if the browser supports webkitOverflowScrolling
+  const WEBKIT_OVERFLOW_SCROLLING = (() => document.createElement('div').style.webkitOverflowScrolling === '')();
+
   /**
    * @polymerMixin
    */
@@ -277,7 +280,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _noInput: {
           type: Boolean,
-          computed: '_isNoInput(_fullscreen, i18n, i18n.*, _ios)'
+          computed: '_isNoInput(_fullscreen, _ios, i18n, i18n.*)'
         },
 
         _ios: {
@@ -307,6 +310,7 @@ This program is available under Apache License Version 2.0, available at https:/
       super.ready();
       this._boundOnScroll = this._onScroll.bind(this);
       this._boundFocus = this._focus.bind(this);
+      this._boundUpdateAlignmentAndPosition = this._updateAlignmentAndPosition.bind(this);
       Polymer.Gestures.addListener(this, 'tap', this.open);
       this.addEventListener('touchend', this._preventDefault.bind(this));
       this.addEventListener('keydown', this._onKeydown.bind(this));
@@ -388,8 +392,8 @@ This program is available under Apache License Version 2.0, available at https:/
       return date;
     }
 
-    _isNoInput() {
-      return !this._inputElement || this._fullscreen || !this.i18n.parseDate || this._ios;
+    _isNoInput(fullscreen, ios, i18n) {
+      return !this._inputElement || fullscreen || ios || !i18n.parseDate;
     }
 
     _formatISO(date) {
@@ -491,13 +495,13 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _updateAlignmentAndPosition() {
-      const bottomAlign = this._inputElement.getBoundingClientRect().top > window.innerHeight / 2;
-      const rightAlign = this._inputElement.getBoundingClientRect().left + this.clientWidth / 2 > window.innerWidth / 2;
+      const inputRect = this._inputElement.getBoundingClientRect();
+
+      const bottomAlign = inputRect.top > window.innerHeight / 2;
+      const rightAlign = inputRect.left + this.clientWidth / 2 > window.innerWidth / 2;
 
       const viewportHeight = Math.min(window.innerHeight, document.documentElement.clientHeight);
       const viewportWidth = Math.min(window.innerWidth, document.documentElement.clientWidth);
-
-      const inputRect = this._inputElement.getBoundingClientRect();
 
       if (!this._fullscreen) {
         if (rightAlign) {
@@ -553,10 +557,9 @@ This program is available under Apache License Version 2.0, available at https:/
       this._ignoreFocusedDateChange = false;
 
       window.addEventListener('scroll', this._boundOnScroll, true);
-      this.listen(this, 'iron-resize', '_updateAlignmentAndPosition');
+      this.addEventListener('iron-resize', this._boundUpdateAlignmentAndPosition);
 
-      // Checking if the browser supports webkitOverflowScrolling
-      if (document.createElement('div').style.webkitOverflowScrolling === '') {
+      if (WEBKIT_OVERFLOW_SCROLLING) {
         this._touchPrevented = this._preventWebkitOverflowScrollingTouch(this.parentElement);
       }
 
@@ -598,7 +601,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._ignoreAnnounce = true;
 
       window.removeEventListener('scroll', this._boundOnScroll, true);
-      this.unlisten(this, 'iron-resize', '_updateAlignmentAndPosition');
+      this.removeEventListener('iron-resize', this._boundUpdateAlignmentAndPosition);
 
       if (this._touchPrevented) {
         this._touchPrevented.forEach(prevented =>

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -18,7 +18,7 @@ This program is available under Apache License Version 2.0, available at https:/
    * @polymerMixin
    */
   Vaadin.DatePickerMixin = subclass => class VaadinDatePickerMixin extends Polymer.mixinBehaviors(
-    [Polymer.IronA11yKeysBehavior, Polymer.IronResizableBehavior], subclass
+    [Polymer.IronResizableBehavior], subclass
   ) {
 
     static get properties() {

--- a/src/vaadin-date-picker-overlay-content.html
+++ b/src/vaadin-date-picker-overlay-content.html
@@ -802,6 +802,15 @@ This program is available under Apache License Version 2.0, available at https:/
           return this.focusedDate || this.selectedDate || this.initialPosition || new Date();
         }
 
+        _focusDate(dateToFocus) {
+          this.focusedDate = dateToFocus;
+          this._focusedMonthDate = dateToFocus.getDate();
+        }
+
+        _focusClosestDate(focus) {
+          this._focusDate(Vaadin.DatePickerHelper._getClosestDate(focus, [this.minDate, this.maxDate]));
+        }
+
         _moveFocusByDays(days) {
           var focus = this._currentlyFocusedDate();
           var dateToFocus = new Date(0, 0);
@@ -810,22 +819,18 @@ This program is available under Apache License Version 2.0, available at https:/
           dateToFocus.setDate(focus.getDate() + days);
 
           if (this._dateAllowed(dateToFocus, this.minDate, this.maxDate)) {
-            this.focusedDate = dateToFocus;
-            this._focusedMonthDate = this.focusedDate.getDate();
+            this._focusDate(dateToFocus);
           } else {
             if (this._dateAllowed(focus, this.minDate, this.maxDate)) {
               // Move to min or max date
               if (days > 0) { // down or right
-                this.focusedDate = this.maxDate;
-                this._focusedMonthDate = this.maxDate.getDate();
+                this._focusDate(this.maxDate);
               } else { // up or left
-                this.focusedDate = this.minDate;
-                this._focusedMonthDate = this.minDate.getDate();
+                this._focusDate(this.minDate);
               }
             } else {
               // Move to closest allowed date
-              this.focusedDate = Vaadin.DatePickerHelper._getClosestDate(focus, [this.minDate, this.maxDate]);
-              this._focusedMonthDate = this.focusedDate.getDate();
+              this._focusClosestDate(focus);
             }
           }
         }
@@ -849,16 +854,13 @@ This program is available under Apache License Version 2.0, available at https:/
             if (this._dateAllowed(focus, this.minDate, this.maxDate)) {
               // Move to min or max date
               if (months > 0) { // pagedown
-                this.focusedDate = this.maxDate;
-                this._focusedMonthDate = this.maxDate.getDate();
+                this._focusDate(this.maxDate);
               } else { // pageup
-                this.focusedDate = this.minDate;
-                this._focusedMonthDate = this.minDate.getDate();
+                this._focusDate(this.minDate);
               }
             } else {
               // Move to closest allowed date
-              this.focusedDate = Vaadin.DatePickerHelper._getClosestDate(focus, [this.minDate, this.maxDate]);
-              this._focusedMonthDate = this.focusedDate.getDate();
+              this._focusClosestDate(focus);
             }
           }
         }
@@ -876,17 +878,14 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           if (this._dateAllowed(dateToFocus, this.minDate, this.maxDate)) {
-            this.focusedDate = dateToFocus;
-            this._focusedMonthDate = this.focusedDate.getDate();
+            this._focusDate(dateToFocus);
           } else {
             if (this._dateAllowed(focusedDate, this.minDate, this.maxDate)) {
               // Move to minDate or maxDate
-              this.focusedDate = this[property];
-              this._focusedMonthDate = this[property].getDate();
+              this._focusDate(this[property]);
             } else {
               // Move to closest allowed date
-              this.focusedDate = Vaadin.DatePickerHelper._getClosestDate(focusedDate, [this.minDate, this.maxDate]);
-              this._focusedMonthDate = this.focusedDate.getDate();
+              this._focusClosestDate(focusedDate);
             }
           }
         }

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -12,7 +12,6 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="vaadin-date-picker-overlay.html">
 <link rel="import" href="vaadin-date-picker-overlay-content.html">
 <link rel="import" href="vaadin-date-picker-mixin.html">
-<link rel="import" href="vaadin-date-picker-helper.html">
 <link rel="import" href="../../vaadin-text-field/src/vaadin-text-field.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
 

--- a/src/vaadin-infinite-scroller.html
+++ b/src/vaadin-infinite-scroller.html
@@ -5,8 +5,10 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../polymer/lib/legacy/class.html">
-<link rel="import" href="../../polymer/lib/legacy/templatizer-behavior.html">
+<link rel="import" href="../../polymer/lib/utils/async.html">
+<link rel="import" href="../../polymer/lib/utils/debounce.html">
+<link rel="import" href="../../polymer/lib/utils/flush.html">
+<link rel="import" href="../../polymer/lib/utils/templatize.html">
 
 <dom-module id="vaadin-infinite-scroller">
   <template>
@@ -309,7 +311,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this.appendChild(itemWrapper);
 
             // This is needed by IE
-            Polymer.dom.flush();
+            Polymer.flush();
 
             setTimeout(() => {
               // Only stamp the visible instances first

--- a/test/basic.html
+++ b/test/basic.html
@@ -305,14 +305,14 @@
       });
 
       it('should realign on iron-resize', done => {
+        sinon.stub(datepicker, '_boundUpdateAlignmentAndPosition', () => {
+          if (!done._called) {
+            done._called = true;
+            done();
+          }
+        });
         open(datepicker, () => {
-          sinon.stub(datepicker, '_updateAlignmentAndPosition', () => {
-            if (!done._called) {
-              done._called = true;
-              done();
-            }
-          });
-          datepicker.fire('iron-resize', undefined, {bubbles: false});
+          datepicker.dispatchEvent(new CustomEvent('iron-resize', {bubbles: false}));
         });
       });
 


### PR DESCRIPTION
Note: removal of `IronA11yKeysBehavior` from `vaadin-combo-box-light` can be potentially breaking change, __but__ it is not used by component itself,nd anyone who wants to extend it can still use `Polymer.mixinBehaviors` himself.