### PR TITLE
Fix aria role for calendar dates

### DIFF
--- a/src/vaadin-month-calendar.html
+++ b/src/vaadin-month-calendar.html
@@ -329,7 +329,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _getRole(date) {
-          return date ? 'button' : 'presentational';
+          return date ? 'button' : 'presentation';
         }
 
         _getAriaLabel(date) {

--- a/test/wai-aria.html
+++ b/test/wai-aria.html
@@ -291,6 +291,15 @@
           });
         });
 
+        it('should have presentation roles on empty date cells', () => {
+          var emptyDateElements = monthCalendar.root.querySelectorAll('[part="date"]:empty');
+
+          Array.prototype.forEach.call(emptyDateElements, emptyElement => {
+            expect(emptyElement.getAttribute('role')).to.equal('presentation');
+            expect(emptyElement.getAttribute('aria-label')).to.be.empty;
+          });
+        });
+
         describe('week numbers', () => {
           beforeEach(done => {
             monthCalendar.showWeekNumbers = true;


### PR DESCRIPTION
Should use `presentation` role for calendar dates: https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/presentation/PresentationRoleExamples.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/610)
<!-- Reviewable:end -->
