### PR TITLE
Use default mouse cursor for overlay content [skip ci]

### DIFF
--- a/theme/lumo/vaadin-date-picker-overlay-content-styles.html
+++ b/theme/lumo/vaadin-date-picker-overlay-content-styles.html
@@ -17,6 +17,7 @@
         background-size: 57px 100%;
         background-position: top right;
         background-repeat: no-repeat;
+        cursor: default;
       }
 
       /* Month scroller */


### PR DESCRIPTION
The content inside the overlay is mostly interactive (vs. plain text content), so it’s more expected to have the same mouse cursor as buttons.