### PR TITLE
Live demo and API Documentation into own section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@
 
 # &lt;vaadin-date-picker&gt;
 
-[Live Demo ↗](https://vaadin.com/components/vaadin-date-picker/html-examples)
-|
-[API documentation ↗](https://vaadin.com/components/vaadin-date-picker/html-api)
-
 [&lt;vaadin-date-picker&gt;](https://vaadin.com/components/vaadin-date-picker) is a Web Component providing a date selection field which includes a scrollable month calendar view, part of the [Vaadin components](https://vaadin.com/components).
 
 <!--
@@ -33,6 +29,11 @@
 ```
 
 [<img src="https://raw.githubusercontent.com/vaadin/vaadin-date-picker/master/screenshot.png" width="439" alt="Screenshot of vaadin-date-picker">](https://vaadin.com/components/vaadin-date-picker)
+
+## Live demo and API Documentation
+[Live Demo ↗](https://vaadin.com/components/vaadin-date-picker/html-examples)
+|
+[API documentation ↗](https://vaadin.com/components/vaadin-date-picker/html-api)
 
 ## Installation
 


### PR DESCRIPTION
The live demo and API documentation links get lost at the top of the document. The first expectations in *most* GitHub repositories is an explanation not links somewhere else. 

Also these are important links and not easy to find when scanning the page. Putting them in their own section improves findability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/622)
<!-- Reviewable:end -->
