### PR TITLE
Fix #654 last day of month wrongly disabled

### DIFF
--- a/src/vaadin-month-calendar.html
+++ b/src/vaadin-month-calendar.html
@@ -194,7 +194,7 @@ This program is available under Apache License Version 2.0, available at https:/
           var lastDate = new Date(0, 0);
           lastDate.setFullYear(month.getFullYear());
           lastDate.setMonth(month.getMonth() + 1);
-          lastDate.setDate(-1);
+          lastDate.setDate(0);
 
           if ((minDate && maxDate)
             && minDate.getMonth() === maxDate.getMonth()


### PR DESCRIPTION
- setDate(-1) sets the date to two days previous, not one

see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate#Description

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/655)
<!-- Reviewable:end -->
