### PR TITLE
Fix enter error before overlay initalized and overlay opening on clear-button click

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -804,7 +804,7 @@ This program is available under Apache License Version 2.0, available at https:/
           const parsedDate = dateObject &&
             this._parseDate(dateObject.year + '-' + (dateObject.month + 1) + '-' + dateObject.day);
 
-          if (this._overlayContent.focusedDate && this._isValidDate(parsedDate)) {
+          if (this._overlayInitialized && this._overlayContent.focusedDate && this._isValidDate(parsedDate)) {
             this._selectedDate = this._overlayContent.focusedDate;
           }
           this.close();

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -838,7 +838,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onUserInput(e) {
-      if (!this.opened) {
+      if (!this.opened && this._inputElement.value) {
         this.open();
       }
       this._userInputValueChanged();

--- a/test/custom-input.html
+++ b/test/custom-input.html
@@ -55,13 +55,13 @@
 
       it('should open calendar on input', done => {
         var target = datepicker._inputElement;
-        target.value = '1';
-        datepicker._nativeInput.dispatchEvent(new CustomEvent('input', {bubbles: true}));
+        target.bindValue = '1';
 
-        listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', () => {
+        listenForEvent(document, 'vaadin-overlay-open', () => {
           expect(datepicker.$.overlay.opened).to.be.true;
           done();
         });
+        datepicker._nativeInput.dispatchEvent(new CustomEvent('input', {bubbles: true}));
       });
 
       it('should show week numbers', () => {

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -290,6 +290,13 @@
           });
         });
 
+        it('should not throw on enter before opening overlay', () => {
+          expect(() => {
+            datepicker.focus();
+            enter();
+          }).not.to.throw(Error);
+        });
+
         describe('no parseDate', () => {
 
           beforeEach(() => {


### PR DESCRIPTION
two fixes in two commits

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/657)
<!-- Reviewable:end -->
