### PR TITLE
Run validation when field is blurred

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -337,7 +337,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('keydown', this._onKeydown.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
-      this.addEventListener('blur', e => !this._noInput && this.validate());
+      this.addEventListener('blur', e => !this.opened && this.validate());
     }
 
     _initOverlay() {

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -488,6 +488,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.__userInputOccurred = true;
       if (!this._ignoreFocusedDateChange && !this._noInput) {
         this._inputValue = focusedDate ? formatDate(Vaadin.DatePickerHelper._extractDateParts(focusedDate)) : '';
+        this.invalid = false;
       }
     }
 

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -335,7 +335,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('keydown', this._onKeydown.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
-      this.addEventListener('blur', e => this.validate());
+      this.addEventListener('blur', e => !this._noInput && this.validate());
     }
 
     _initOverlay() {

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -335,6 +335,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('keydown', this._onKeydown.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
+      this.addEventListener('blur', e => this.validate());
     }
 
     _initOverlay() {

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -328,6 +328,8 @@ This program is available under Apache License Version 2.0, available at https:/
             .length === 0
         ) {
           this.open();
+        } else {
+          this.validate();
         }
       });
 

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -477,7 +477,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       this.__userInputOccurred = false;
       this.__dispatchChange = false;
+      this._ignoreFocusedDateChange = true;
       this._focusedDate = selectedDate;
+      this._ignoreFocusedDateChange = false;
       this._inputValue = selectedDate ? inputValue : '';
     }
 

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -270,6 +270,22 @@
           datepicker.close();
         });
 
+        it('should validate on clear button', done => {
+          datepicker.clearButtonVisible = true;
+          const clearButton = target.shadowRoot.querySelector('[part="clear-button"]');
+          inputText('foo');
+          datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
+            // wait for overlay to finish closing. Without this, clear button click
+            // will trigger "close()" again, which will result in infinite loop.
+            Polymer.RenderStatus.afterNextRender(datepicker, () => {
+              click(clearButton);
+              expect(datepicker.invalid).to.equal(false);
+              done();
+            });
+          });
+          datepicker.close();
+        });
+
         it('should empty value with false input', done => {
           datepicker.value = '2000-01-01';
           target.value = '';

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -257,15 +257,18 @@
           });
         });
 
-        it('should validate on blur', done => {
+        it('should validate on blur when not opened', done => {
           inputText('foo');
           datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-            target.value = '';
-            var spy = sinon.spy(datepicker, 'validate');
-            datepicker.dispatchEvent(new Event('blur'));
-            expect(spy).to.be.calledOnce;
-            expect(datepicker.invalid).to.be.false;
-            done();
+            // wait for overlay to finish closing
+            Polymer.RenderStatus.afterNextRender(datepicker, () => {
+              target.value = '';
+              var spy = sinon.spy(datepicker, 'validate');
+              datepicker.dispatchEvent(new Event('blur'));
+              expect(spy).to.be.calledOnce;
+              expect(datepicker.invalid).to.be.false;
+              done();
+            });
           });
           datepicker.close();
         });

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -257,6 +257,19 @@
           });
         });
 
+        it('should validate on blur', done => {
+          inputText('foo');
+          datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
+            target.value = '';
+            var spy = sinon.spy(datepicker, 'validate');
+            datepicker.dispatchEvent(new Event('blur'));
+            expect(spy).to.be.calledOnce;
+            expect(datepicker.invalid).to.be.false;
+            done();
+          });
+          datepicker.close();
+        });
+
         it('should empty value with false input', done => {
           datepicker.value = '2000-01-01';
           target.value = '';


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-date-picker-flow/issues/201

If you can come up with any potential side-effects of running validation on blur, that would be great to catch before merging 🤗

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/679)
<!-- Reviewable:end -->
