### PR TITLE
Revert "Clear invalid state when focused date is changed"

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -497,7 +497,6 @@ This program is available under Apache License Version 2.0, available at https:/
       this.__userInputOccurred = true;
       if (!this._ignoreFocusedDateChange && !this._noInput) {
         this._inputValue = focusedDate ? formatDate(Vaadin.DatePickerHelper._extractDateParts(focusedDate)) : '';
-        this.invalid = false;
       }
     }
 


### PR DESCRIPTION
This reverts commit 4431ab98775ac513a25bd6a08bc08794cd71005a.

The change by @jouni resulted in initially `invalid` date-picker to become valid on empty value.
Let's revert the change. There is no test for it. We can re-add with the actual test later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-date-picker/684)
<!-- Reviewable:end -->
