### PR TITLE
add alignment for left-aligned rtl

### DIFF
--- a/src/vaadin-date-picker-styles.html
+++ b/src/vaadin-date-picker-styles.html
@@ -8,6 +8,10 @@
         justify-content: flex-start;
       }
 
+      :host([dir="rtl"]) {
+        align-items: flex-end;
+      }
+
       :host([bottom-aligned]) {
         justify-content: flex-end;
       }


### PR DESCRIPTION
Currently `align-items` is specified for:
-  left-aligned ltr, i.e. `:host`
- right-aligned ltr, i.e. `:host([right-aligned])`
- right-aligned rtl, i.e. `:host([right-aligned][dir="rtl"])`
But it's missing a specification for 
- left-aligned rtl, i.e. `:host([dir="rtl"])`
This PR adds this spec, which fixes mis-aligned overlays in the missing case.