### PR TITLE
Add autoOpenDisabled property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,7 @@
     "iron-resizable-behavior": "^2.0.0",
     "polymer": "^2.0.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.0",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.3.0",
+    "vaadin-text-field": "vaadin/vaadin-text-field#^2.4.3",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.3.2",
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
     "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0",

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -347,8 +347,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
       this.addEventListener('blur', e => {
-        this.autoOpenDisabled && this._selectAndValidateInput();
-        return !this.opened && this.validate();
+        this.autoOpenDisabled ? this._selectAndValidateInput() : !this.opened && this.validate();
       });
     }
 

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -346,7 +346,10 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('keydown', this._onKeydown.bind(this));
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
-      this.addEventListener('blur', e => !this.opened && this.validate());
+      this.addEventListener('blur', e => {
+        this.autoOpenDisabled && this._onOverlayClosed();
+        !this.opened && this.validate();
+      });
     }
 
     _initOverlay() {

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -333,7 +333,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // then the following composedPath check could be simplified down
         // to `if (!e.defaultPrevented)`.
         // https://github.com/vaadin/vaadin-text-field/issues/352
-        if (!isClearButton(e) && !this.autoOpenDisabled) {
+        if (!isClearButton(e) && (!this.autoOpenDisabled || this._noInput)) {
           this.open();
         }
       });

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -413,7 +413,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * Closes the dropdown.
      */
     close() {
-      if (this._overlayInitialized) {
+      if (this._overlayInitialized || this.autoOpenDisabled) {
         this.$.overlay.close();
       }
     }
@@ -868,7 +868,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _userInputValueChanged(value) {
-      if (this.opened && this._inputValue) {
+      if ((this.opened || this.autoOpenDisabled) && this._inputValue) {
         const dateObject = this.i18n.parseDate && this.i18n.parseDate(this._inputValue);
         const parsedDate = dateObject &&
           this._parseDate(`${dateObject.year}-${dateObject.month + 1}-${dateObject.day}`);

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -83,6 +83,11 @@ This program is available under Apache License Version 2.0, available at https:/
         },
 
         /**
+         * Set true to prevent the overlay from opening automatically.
+         */
+        autoOpenDisabled: Boolean,
+
+        /**
          * Set true to display ISO-8601 week numbers in the calendar. Notice that
          * displaying week numbers is only supported when `i18n.firstDayOfWeek`
          * is 1 (Monday).
@@ -328,7 +333,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // then the following composedPath check could be simplified down
         // to `if (!e.defaultPrevented)`.
         // https://github.com/vaadin/vaadin-text-field/issues/352
-        if (!isClearButton(e)) {
+        if (!isClearButton(e) && !this.autoOpenDisabled) {
           this.open();
         }
       });
@@ -853,7 +858,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onUserInput(e) {
-      if (!this.opened && this._inputElement.value) {
+      if (!this.opened && this._inputElement.value && !this.autoOpenDisabled) {
         this.open();
       }
       this._userInputValueChanged();

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -347,8 +347,8 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
       this.addEventListener('blur', e => {
-        this.autoOpenDisabled && this._onOverlayClosed();
-        !this.opened && this.validate();
+        this.autoOpenDisabled && this._selectAndValidateInput();
+        return !this.opened && this.validate();
       });
     }
 
@@ -691,9 +691,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._ignoreFocusedDateChange = true;
       if (this.i18n.parseDate) {
         var inputValue = this._inputValue || '';
-        const dateObject = this.i18n.parseDate(inputValue);
-        const parsedDate = dateObject &&
-          this._parseDate(`${dateObject.year}-${dateObject.month + 1}-${dateObject.day}`);
+        const parsedDate = this._getParsedDate(inputValue);
 
         if (this._isValidDate(parsedDate)) {
           this._selectedDate = parsedDate;
@@ -829,19 +827,24 @@ This program is available under Apache License Version 2.0, available at https:/
 
           break;
         case 'enter': {
-          const dateObject = this.i18n.parseDate(this._inputValue);
-          const parsedDate = dateObject &&
-            this._parseDate(dateObject.year + '-' + (dateObject.month + 1) + '-' + dateObject.day);
-
-          if (this._overlayInitialized && this._overlayContent.focusedDate && this._isValidDate(parsedDate)) {
-            this._selectedDate = this._overlayContent.focusedDate;
+          if (this.autoOpenDisabled) {
+            this._selectAndValidateInput();
+          } else {
+            const parsedDate = this._getParsedDate();
+            if (this._overlayInitialized && this._overlayContent.focusedDate && this._isValidDate(parsedDate)) {
+              this._selectedDate = this._overlayContent.focusedDate;
+            }
+            this.close();
           }
-          this.close();
           break;
         }
         case 'esc':
-          this._focusedDate = this._selectedDate;
-          this._close();
+          if (this.autoOpenDisabled) {
+            this._inputElement.value = this.value;
+          } else {
+            this._focusedDate = this._selectedDate;
+            this._close();
+          }
           break;
         case 'tab':
           if (this.opened) {
@@ -860,6 +863,21 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    _selectAndValidateInput() {
+      const parsedDate = this._getParsedDate();
+      if (this._isValidDate(parsedDate)) {
+        this._selectedDate = parsedDate;
+      }
+      this.validate();
+    }
+
+    _getParsedDate(inputValue = this._inputValue) {
+      const dateObject = this.i18n.parseDate && this.i18n.parseDate(inputValue);
+      const parsedDate = dateObject &&
+        this._parseDate(dateObject.year + '-' + (dateObject.month + 1) + '-' + dateObject.day);
+      return parsedDate;
+    }
+
     _onUserInput(e) {
       if (!this.opened && this._inputElement.value && !this.autoOpenDisabled) {
         this.open();
@@ -868,10 +886,8 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _userInputValueChanged(value) {
-      if ((this.opened || this.autoOpenDisabled) && this._inputValue) {
-        const dateObject = this.i18n.parseDate && this.i18n.parseDate(this._inputValue);
-        const parsedDate = dateObject &&
-          this._parseDate(`${dateObject.year}-${dateObject.month + 1}-${dateObject.day}`);
+      if (this.opened && this._inputValue) {
+        const parsedDate = this._getParsedDate();
 
         if (this._isValidDate(parsedDate)) {
           this._ignoreFocusedDateChange = true;

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -355,7 +355,13 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           }
 
-          this.validate();
+          if (this._inputElement.value === '' && this.__dispatchChange) {
+            this.validate();
+            this.value = '';
+            this.__dispatchChange = false;
+          } else {
+            this.validate();
+          }
         }
       });
     }
@@ -680,20 +686,7 @@ This program is available under Apache License Version 2.0, available at https:/
       return result;
     }
 
-    _onOverlayClosed() {
-      this._ignoreAnnounce = true;
-
-      window.removeEventListener('scroll', this._boundOnScroll, true);
-      this.removeEventListener('iron-resize', this._boundUpdateAlignmentAndPosition);
-
-      if (this._touchPrevented) {
-        this._touchPrevented.forEach(prevented =>
-          prevented.element.style.webkitOverflowScrolling = prevented.oldInlineValue);
-        this._touchPrevented = [];
-      }
-
-      this.updateStyles();
-
+    _selectParsedOrFocusedDate() {
       // Select the parsed input or focused date
       this._ignoreFocusedDateChange = true;
       if (this.i18n.parseDate) {
@@ -710,13 +703,32 @@ This program is available under Apache License Version 2.0, available at https:/
         this._selectedDate = this._focusedDate;
       }
       this._ignoreFocusedDateChange = false;
+    }
+
+    _onOverlayClosed() {
+      this._ignoreAnnounce = true;
+
+      window.removeEventListener('scroll', this._boundOnScroll, true);
+      this.removeEventListener('iron-resize', this._boundUpdateAlignmentAndPosition);
+
+      if (this._touchPrevented) {
+        this._touchPrevented.forEach(prevented =>
+          prevented.element.style.webkitOverflowScrolling = prevented.oldInlineValue);
+        this._touchPrevented = [];
+      }
+
+      this.updateStyles();
+
+      this._selectParsedOrFocusedDate();
 
       if (this._nativeInput && this._nativeInput.selectionStart) {
         this._nativeInput.selectionStart = this._nativeInput.selectionEnd;
       }
       // No need to revalidate the value after `_selectedDateChanged`
       // Needed in case the value was not changed: open and close dropdown.
-      !this.value && this.validate();
+      if (!this.value) {
+        this.validate();
+      }
     }
 
     /**
@@ -826,8 +838,6 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
-      const isAutoOpenDisabled = this.autoOpenDisabled && !this.opened;
-
       switch (this._eventKey(e)) {
         case 'down':
         case 'up':
@@ -846,21 +856,29 @@ This program is available under Apache License Version 2.0, available at https:/
         case 'enter': {
           const parsedDate = this._getParsedDate();
           const isValidDate = this._isValidDate(parsedDate);
-          if (isAutoOpenDisabled) {
-            if (isValidDate) {
-              this._selectedDate = parsedDate;
-            }
-            this.validate();
-          } else {
+          if (this.opened) {
             if (this._overlayInitialized && this._overlayContent.focusedDate && isValidDate) {
               this._selectedDate = this._overlayContent.focusedDate;
             }
             this.close();
+          } else {
+            if (!isValidDate && this._inputElement.value !== '') {
+              this.validate();
+            } else {
+              const oldValue = this.value;
+              this._selectParsedOrFocusedDate();
+              if (oldValue === this.value) {
+                this.validate();
+              }
+            }
           }
           break;
         }
         case 'esc':
-          if (isAutoOpenDisabled) {
+          if (this.opened) {
+            this._focusedDate = this._selectedDate;
+            this._close();
+          } else if (this.autoOpenDisabled) {
             // Do not restore selected date if Esc was pressed after clearing input field
             if (this._inputElement.value === '') {
               this._selectedDate = null;
@@ -868,7 +886,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this._applyInputValue(this._selectedDate);
           } else {
             this._focusedDate = this._selectedDate;
-            this._close();
+            this._selectParsedOrFocusedDate();
           }
           break;
         case 'tab':
@@ -900,6 +918,13 @@ This program is available under Apache License Version 2.0, available at https:/
         this.open();
       }
       this._userInputValueChanged();
+
+      if (e.__fromClearButton) {
+        this.validate();
+        this.__dispatchChange = true;
+        this.value = '';
+        this.__dispatchChange = false;
+      }
     }
 
     _userInputValueChanged(value) {

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -347,7 +347,16 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('input', this._onUserInput.bind(this));
       this.addEventListener('focus', e => this._noInput && e.target.blur());
       this.addEventListener('blur', e => {
-        this.autoOpenDisabled ? this._selectAndValidateInput() : !this.opened && this.validate();
+        if (!this.opened) {
+          if (this.autoOpenDisabled) {
+            const parsedDate = this._getParsedDate();
+            if (this._isValidDate(parsedDate)) {
+              this._selectedDate = parsedDate;
+            }
+          }
+
+          this.validate();
+        }
       });
     }
 
@@ -373,7 +382,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
       };
-  
+
       this.addEventListener('mousedown', bringToFrontListener);
       this.addEventListener('touchstart', bringToFrontListener);
     }
@@ -493,9 +502,8 @@ This program is available under Apache License Version 2.0, available at https:/
       if (this.__userInputOccurred) {
         this.__dispatchChange = true;
       }
-      const inputValue = selectedDate && formatDate(Vaadin.DatePickerHelper._extractDateParts(selectedDate));
       const value = this._formatISO(selectedDate);
-      this._inputValue = selectedDate ? inputValue : '';
+      this._applyInputValue(selectedDate);
       if (value !== this.value) {
         this.validate();
         this.value = value;
@@ -513,7 +521,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       this.__userInputOccurred = true;
       if (!this._ignoreFocusedDateChange && !this._noInput) {
-        this._inputValue = focusedDate ? formatDate(Vaadin.DatePickerHelper._extractDateParts(focusedDate)) : '';
+        this._applyInputValue(focusedDate);
       }
     }
 
@@ -734,7 +742,7 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     checkValidity() {
       const inputValid = !this._inputValue ||
-        (this._selectedDate && this._inputValue === this.i18n.formatDate(Vaadin.DatePickerHelper._extractDateParts(this._selectedDate)));
+        (this._selectedDate && this._inputValue === this._getFormattedDate(this.i18n.formatDate, this._selectedDate));
       const minMaxValid = !this._selectedDate ||
         Vaadin.DatePickerHelper._dateAllowed(this._selectedDate, this._minDate, this._maxDate);
 
@@ -771,6 +779,14 @@ This program is available under Apache License Version 2.0, available at https:/
     _focusAndSelect() {
       this._focus();
       this._setSelectionRange(0, this._inputValue.length);
+    }
+
+    _applyInputValue(date) {
+      this._inputValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
+    }
+
+    _getFormattedDate(formatDate, date) {
+      return formatDate(Vaadin.DatePickerHelper._extractDateParts(date));
     }
 
     _setSelectionRange(a, b) {
@@ -810,6 +826,8 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
+      const isAutoOpenDisabled = this.autoOpenDisabled && !this.opened;
+
       switch (this._eventKey(e)) {
         case 'down':
         case 'up':
@@ -826,11 +844,15 @@ This program is available under Apache License Version 2.0, available at https:/
 
           break;
         case 'enter': {
-          if (this.autoOpenDisabled) {
-            this._selectAndValidateInput();
+          const parsedDate = this._getParsedDate();
+          const isValidDate = this._isValidDate(parsedDate);
+          if (isAutoOpenDisabled) {
+            if (isValidDate) {
+              this._selectedDate = parsedDate;
+            }
+            this.validate();
           } else {
-            const parsedDate = this._getParsedDate();
-            if (this._overlayInitialized && this._overlayContent.focusedDate && this._isValidDate(parsedDate)) {
+            if (this._overlayInitialized && this._overlayContent.focusedDate && isValidDate) {
               this._selectedDate = this._overlayContent.focusedDate;
             }
             this.close();
@@ -838,8 +860,12 @@ This program is available under Apache License Version 2.0, available at https:/
           break;
         }
         case 'esc':
-          if (this.autoOpenDisabled) {
-            this._inputElement.value = this.value;
+          if (isAutoOpenDisabled) {
+            // Do not restore selected date if Esc was pressed after clearing input field
+            if (this._inputElement.value === '') {
+              this._selectedDate = null;
+            }
+            this._applyInputValue(this._selectedDate);
           } else {
             this._focusedDate = this._selectedDate;
             this._close();
@@ -860,14 +886,6 @@ This program is available under Apache License Version 2.0, available at https:/
           }
           break;
       }
-    }
-
-    _selectAndValidateInput() {
-      const parsedDate = this._getParsedDate();
-      if (this._isValidDate(parsedDate)) {
-        this._selectedDate = parsedDate;
-      }
-      this.validate();
     }
 
     _getParsedDate(inputValue = this._inputValue) {

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -256,15 +256,11 @@ This program is available under Apache License Version 2.0, available at https:/
           // In order to have synchronized invalid property, we need to use the same validate logic.
           Polymer.RenderStatus.afterNextRender(this, () => this._inputElement.validate = () => {});
 
-          // FIXME(platosha): dispatch `input` event on
-          // <vaadin-text-field> clear button
-          // https://github.com/vaadin/vaadin-text-field/issues/347
-          this._inputElement.addEventListener('change', () => {
-            if (this._inputElement.value === '') {
+          this._inputElement.addEventListener('change', (e) => {
+            // For change event on text-field blur, after the field is cleared,
+            // we schedule change event to be dispatched on date-picker blur.
+            if (this._inputElement.value === '' && !e.__fromClearButton) {
               this.__dispatchChange = true;
-              this.value = '';
-              this.validate();
-              this.__dispatchChange = false;
             }
           });
         }

--- a/test/basic.html
+++ b/test/basic.html
@@ -148,6 +148,12 @@
         listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', done);
       });
 
+      it('should not open on input tap when autoOpenDisabled is true', () => {
+        datepicker.autoOpenDisabled = true;
+        tap(datepicker.$.input);
+        expect(datepicker.opened).not.to.be.true;
+      });
+
       it('should pass the placeholder attribute to the input tag', () => {
         var placeholder = 'Pick a date';
         datepicker.set('placeholder', placeholder);
@@ -236,6 +242,12 @@
       });
 
       it('should open by tapping the calendar icon', done => {
+        tap(toggleButton);
+        listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', done);
+      });
+
+      it('should open by tapping the calendar icon even if autoOpenDisabled is true', done => {
+        this.autoOpenDisabled = true;
         tap(toggleButton);
         listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', done);
       });

--- a/test/basic.html
+++ b/test/basic.html
@@ -148,10 +148,14 @@
         listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', done);
       });
 
-      it('should not open on input tap when autoOpenDisabled is true', () => {
+      it('should not open on input tap when autoOpenDisabled is true and not on mobile', () => {
         datepicker.autoOpenDisabled = true;
         tap(datepicker.$.input);
-        expect(datepicker.opened).not.to.be.true;
+        if (!datepicker._noInput) {
+          expect(datepicker.opened).not.to.be.true;
+        } else {
+          expect(datepicker.opened).to.be.true;
+        }
       });
 
       it('should pass the placeholder attribute to the input tag', () => {

--- a/test/custom-input.html
+++ b/test/custom-input.html
@@ -64,6 +64,14 @@
         datepicker._nativeInput.dispatchEvent(new CustomEvent('input', {bubbles: true}));
       });
 
+      it('should not open calendar on input when autoOpenDisabled is true', () => {
+        var target = datepicker._inputElement;
+        datepicker.autoOpenDisabled = true;
+        target.bindValue = '1';
+        datepicker._nativeInput.dispatchEvent(new CustomEvent('input', {bubbles: true}));
+        expect(datepicker.$.overlay.opened).not.to.be.true;
+      });
+
       it('should show week numbers', () => {
         datepicker.showWeekNumbers = true;
         expect(overlayContent.showWeekNumbers).to.equal(true);

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -90,6 +90,20 @@
           expect(datepicker.opened).not.to.be.true;
         });
 
+        it('should set datepicker value on blur if autoOpenDisabled is true', () => {
+          datepicker.autoOpenDisabled = true;
+          inputChar('1/1/2000');
+          datepicker.dispatchEvent(new Event('blur'));
+          expect(datepicker.value).to.equal('2000-01-01');
+        });
+
+        it('should not be invalid on blur if valid date is enetered and autoOpenDisabled is true', () => {
+          datepicker.autoOpenDisabled = true;
+          inputChar('1/1/2000');
+          datepicker.dispatchEvent(new Event('blur'));
+          expect(datepicker.invalid).not.to.be.true;
+        });
+
         it('should not focus with unparseable date', () => {
           inputChar('j');
 

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -84,6 +84,12 @@
           expect(datepicker.opened).to.be.true;
         });
 
+        it('should not open overlay on input if autoOpenDisabled is true', () => {
+          datepicker.autoOpenDisabled = true;
+          inputChar('j');
+          expect(datepicker.opened).not.to.be.true;
+        });
+
         it('should not focus with unparseable date', () => {
           inputChar('j');
 

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -84,26 +84,6 @@
           expect(datepicker.opened).to.be.true;
         });
 
-        it('should not open overlay on input if autoOpenDisabled is true', () => {
-          datepicker.autoOpenDisabled = true;
-          inputChar('j');
-          expect(datepicker.opened).not.to.be.true;
-        });
-
-        it('should set datepicker value on blur if autoOpenDisabled is true', () => {
-          datepicker.autoOpenDisabled = true;
-          inputChar('1/1/2000');
-          datepicker.dispatchEvent(new Event('blur'));
-          expect(datepicker.value).to.equal('2000-01-01');
-        });
-
-        it('should not be invalid on blur if valid date is enetered and autoOpenDisabled is true', () => {
-          datepicker.autoOpenDisabled = true;
-          inputChar('1/1/2000');
-          datepicker.dispatchEvent(new Event('blur'));
-          expect(datepicker.invalid).not.to.be.true;
-        });
-
         it('should not focus with unparseable date', () => {
           inputChar('j');
 
@@ -720,6 +700,66 @@
 
         });
 
+        describe('auto-open-disabled', () => {
+
+          beforeEach(() => {
+            datepicker.autoOpenDisabled = true;
+          });
+
+          it('should not open overlay on input', () => {
+            inputChar('j');
+            expect(datepicker.opened).not.to.be.true;
+          });
+
+          it('should set datepicker value on blur', () => {
+            inputChar('1/1/2000');
+            datepicker.dispatchEvent(new Event('blur'));
+            expect(datepicker.value).to.equal('2000-01-01');
+          });
+
+          it('should not be invalid on blur if valid date is entered', () => {
+            inputChar('1/1/2000');
+            datepicker.dispatchEvent(new Event('blur'));
+            expect(datepicker.invalid).not.to.be.true;
+          });
+
+          it('should revert input value on esc when overlay not initialized', () => {
+            inputChar('1/1/2000');
+            esc();
+            expect(datepicker._inputValue).to.equal('');
+            expect(datepicker.value).to.equal('');
+          });
+
+          it('should revert input value on esc when overlay has been initialized', () => {
+            datepicker.open();
+            datepicker.close();
+            inputChar('1/1/2000');
+            esc();
+            expect(datepicker._inputValue).to.equal('');
+            expect(datepicker.value).to.equal('');
+          });
+
+          it('should apply the input value on enter when overlay not initialized', () => {
+            inputChar('1/1/2000');
+            enter();
+            expect(datepicker.value).to.equal('2000-01-01');
+          });
+
+          it('should apply input value on enter when overlay has been initialized', () => {
+            datepicker.open();
+            datepicker.close();
+            inputChar('1/1/2000');
+            esc();
+            expect(datepicker.value).to.equal('');
+          });
+
+          it('should be invalid on enter with false input', () => {
+            inputChar('foo');
+            enter();
+            expect(datepicker.value).to.equal('');
+            expect(datepicker.invalid).to.be.true;
+          });
+        });
       });
     }
   </script>

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -700,7 +700,7 @@
 
         });
 
-        describe('auto-open-disabled', () => {
+        describe('auto open disabled', () => {
 
           beforeEach(() => {
             datepicker.autoOpenDisabled = true;
@@ -712,19 +712,19 @@
           });
 
           it('should set datepicker value on blur', () => {
-            inputChar('1/1/2000');
+            inputText('1/1/2000');
             datepicker.dispatchEvent(new Event('blur'));
             expect(datepicker.value).to.equal('2000-01-01');
           });
 
           it('should not be invalid on blur if valid date is entered', () => {
-            inputChar('1/1/2000');
+            inputText('1/1/2000');
             datepicker.dispatchEvent(new Event('blur'));
             expect(datepicker.invalid).not.to.be.true;
           });
 
           it('should revert input value on esc when overlay not initialized', () => {
-            inputChar('1/1/2000');
+            inputText('1/1/2000');
             esc();
             expect(datepicker._inputValue).to.equal('');
             expect(datepicker.value).to.equal('');
@@ -733,14 +733,14 @@
           it('should revert input value on esc when overlay has been initialized', () => {
             datepicker.open();
             datepicker.close();
-            inputChar('1/1/2000');
+            inputText('1/1/2000');
             esc();
             expect(datepicker._inputValue).to.equal('');
             expect(datepicker.value).to.equal('');
           });
 
           it('should apply the input value on enter when overlay not initialized', () => {
-            inputChar('1/1/2000');
+            inputText('1/1/2000');
             enter();
             expect(datepicker.value).to.equal('2000-01-01');
           });
@@ -748,13 +748,13 @@
           it('should apply input value on enter when overlay has been initialized', () => {
             datepicker.open();
             datepicker.close();
-            inputChar('1/1/2000');
-            esc();
-            expect(datepicker.value).to.equal('');
+            inputText('1/1/2000');
+            enter();
+            expect(datepicker.value).to.equal('2000-01-01');
           });
 
           it('should be invalid on enter with false input', () => {
-            inputChar('foo');
+            inputText('foo');
             enter();
             expect(datepicker.value).to.equal('');
             expect(datepicker.invalid).to.be.true;

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -776,6 +776,202 @@
             expect(datepicker.invalid).to.be.true;
           });
         });
+
+        describe('change and validate sequence', () => {
+          let validateSpy;
+          let changeSpy;
+
+          beforeEach(() => {
+            validateSpy = sinon.spy(datepicker, 'validate');
+            changeSpy = sinon.spy();
+            datepicker.addEventListener('change', changeSpy);
+          });
+
+          describe('overlay is open and value selected', () => {
+            beforeEach(done => {
+              open(datepicker, () => {
+                inputText('01/02/20');
+                done();
+              });
+            });
+
+            it('should validate without change on Esc', done => {
+              datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
+                // wait for overlay to finish closing
+                Polymer.RenderStatus.afterNextRender(datepicker, () => {
+                  expect(validateSpy).to.be.calledOnce;
+                  expect(changeSpy).to.not.be.called;
+                  done();
+                });
+              });
+
+              esc();
+            });
+
+            it('should change after validate on overlay close', done => {
+              datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
+                // wait for overlay to finish closing
+                Polymer.RenderStatus.afterNextRender(datepicker, () => {
+                  expect(validateSpy).to.be.calledOnce;
+                  expect(changeSpy).to.be.calledOnce;
+                  expect(changeSpy).to.be.calledAfter(validateSpy);
+                  done();
+                });
+              });
+
+              datepicker.close();
+            });
+
+            it('should change after validate on Enter', done => {
+              datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
+                // wait for overlay to finish closing
+                Polymer.RenderStatus.afterNextRender(datepicker, () => {
+                  expect(validateSpy).to.be.calledOnce;
+                  expect(changeSpy).to.be.calledOnce;
+                  expect(changeSpy).to.be.calledAfter(validateSpy);
+                  done();
+                });
+              });
+
+              enter();
+            });
+          });
+
+          describe('overlay is closed, value is set', () => {
+            beforeEach(done => {
+              open(datepicker, () => {
+                inputText('01/02/20');
+                datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
+                  // wait for overlay to finish closing
+                  Polymer.RenderStatus.afterNextRender(datepicker, () => {
+                    datepicker._focus();
+                    done();
+                  });
+                });
+
+                datepicker.close();
+                validateSpy.reset();
+                changeSpy.reset();
+              });
+            });
+
+            it('should change after validate on clear button click', () => {
+              datepicker.clearButtonVisible = true;
+              click(target.shadowRoot.querySelector('[part="clear-button"]'));
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledAfter(validateSpy);
+            });
+
+            it('should change after validate on Esc with clear button', () => {
+              datepicker.clearButtonVisible = true;
+              esc();
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledAfter(validateSpy);
+            });
+
+            it('should neither change nor validate on Esc without clear button', () => {
+              esc();
+              expect(validateSpy).to.not.be.called;
+              expect(changeSpy).to.not.be.called;
+            });
+
+            it('should change after validate on Backspace & Enter', () => {
+              target.value = '';
+              target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+              enter();
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledAfter(validateSpy);
+            });
+
+            it('should change after validate on Backspace & Esc', () => {
+              target.value = '';
+              target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+              esc();
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledAfter(validateSpy);
+            });
+          });
+
+          describe('autoOpenDisabled true', () => {
+            beforeEach(() => {
+              datepicker.autoOpenDisabled = true;
+            });
+
+            it('should change after validate on Enter', () => {
+              inputText('01/02/20');
+              enter();
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledOnce;
+              expect(changeSpy).to.be.calledAfter(validateSpy);
+            });
+
+            it('should validate on Enter when value is the same', () => {
+              enter();
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.not.be.called;
+            });
+
+            it('should validate on Enter when invalid', () => {
+              inputText('foo');
+              enter();
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.not.be.called;
+            });
+
+            it('should neither change nor validate on Esc', () => {
+              inputText('01/02/20');
+              esc();
+              expect(validateSpy).to.not.be.called;
+              expect(changeSpy).to.not.be.called;
+            });
+
+            describe('value is set', () => {
+              beforeEach(() => {
+                inputText('01/02/20');
+                enter();
+                validateSpy.reset();
+                changeSpy.reset();
+                datepicker._focusAndSelect();
+              });
+
+              it('should change after validate on Esc with clear button', () => {
+                datepicker.clearButtonVisible = true;
+                esc();
+                expect(validateSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledAfter(validateSpy);
+              });
+
+              it('should neither change nor validate on Esc without clear button', () => {
+                esc();
+                expect(validateSpy).to.not.be.called;
+                expect(changeSpy).to.not.be.called;
+              });
+
+              it('should change after validate on Backspace & Enter', () => {
+                target.value = '';
+                target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+                enter();
+                expect(validateSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledAfter(validateSpy);
+              });
+
+              it('should change after validate on Backspace & Esc', () => {
+                target.value = '';
+                target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+                esc();
+                expect(validateSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledAfter(validateSpy);
+              });
+            });
+          });
+        });
       });
     }
   </script>

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -922,6 +922,12 @@
               expect(changeSpy).to.not.be.called;
             });
 
+            it('should validate on blur', () => {
+              datepicker.dispatchEvent(new Event('blur'));
+              expect(validateSpy).to.be.calledOnce;
+              expect(changeSpy).to.not.be.called;
+            });
+
             it('should neither change nor validate on Esc', () => {
               inputText('01/02/20');
               esc();
@@ -965,6 +971,15 @@
                 target.value = '';
                 target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
                 esc();
+                expect(validateSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledOnce;
+                expect(changeSpy).to.be.calledAfter(validateSpy);
+              });
+
+              it('should change after validate on Backspace & blur', () => {
+                target.value = '';
+                target.dispatchEvent(new CustomEvent('change', {bubbles: true}));
+                datepicker.dispatchEvent(new Event('blur'));
                 expect(validateSpy).to.be.calledOnce;
                 expect(changeSpy).to.be.calledOnce;
                 expect(changeSpy).to.be.calledAfter(validateSpy);

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -723,6 +723,14 @@
             expect(datepicker.invalid).not.to.be.true;
           });
 
+          it('should validate on blur only once', () => {
+            inputText('foo');
+            const spy = sinon.spy(datepicker, 'validate');
+            datepicker.dispatchEvent(new Event('blur'));
+            expect(spy).to.be.calledOnce;
+            expect(datepicker.invalid).to.be.true;
+          });
+
           it('should revert input value on esc when overlay not initialized', () => {
             inputText('1/1/2000');
             esc();

--- a/test/keyboard-input.html
+++ b/test/keyboard-input.html
@@ -743,7 +743,15 @@
             datepicker.close();
             inputText('1/1/2000');
             esc();
-            expect(datepicker._inputValue).to.equal('');
+            expect(datepicker.value).to.equal('');
+          });
+
+          it('should not revert input value on esc after selected value is removed', () => {
+            datepicker.open();
+            inputText('1/1/2000');
+            datepicker.close();
+            target.value = '';
+            esc();
             expect(datepicker.value).to.equal('');
           });
 

--- a/test/keyboard-navigation.html
+++ b/test/keyboard-navigation.html
@@ -96,7 +96,23 @@
             expect(datepicker.opened).to.be.true;
           });
 
+          it('should open overlay on down even if autoOpenDisabled is true', () => {
+            datepicker.autoOpenDisabled = true;
+            target = datepicker.$.input;
+            arrowDown();
+
+            expect(datepicker.opened).to.be.true;
+          });
+
           it('should open overlay on up', () => {
+            target = datepicker.$.input;
+            arrowUp();
+
+            expect(datepicker.opened).to.be.true;
+          });
+
+          it('should open overlay on up even if autoOpenDisabled is true', () => {
+            datepicker.autoOpenDisabled = true;
             target = datepicker.$.input;
             arrowUp();
 


### PR DESCRIPTION
When `datePicker.autoOpenDisabled = true`:
- Focusing and typing in field doesn’t open the overlay
- Clicking on icon opens the overlay
- Up / Down keys opens the overlay
