### PR TITLE
Fix flipped overlay alignment with RTL

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "ignoreWarnings": ["overriding-private"]
+  }
+}

--- a/src/vaadin-date-picker-styles.html
+++ b/src/vaadin-date-picker-styles.html
@@ -16,7 +16,11 @@
         align-items: flex-end;
       }
 
-      :host([right-aligned][dir="rtl"]) {
+      :host([dir="rtl"]) {
+        align-items: flex-end;
+      }
+
+      :host([dir="rtl"][right-aligned]) {
         align-items: flex-start;
       }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -621,22 +621,6 @@
         });
       });
 
-      describe('Right-to-left', () => {
-        before(() => {
-          document.querySelector('body').setAttribute('dir', 'rtl');
-        });
-
-        after(() => {
-          document.querySelector('body').removeAttribute('dir');
-        });
-
-        it('overlay should position correctly', () => {
-          datepicker.open();
-          expect((getOverlayContent(datepicker).getBoundingClientRect().right >= datepicker.getBoundingClientRect().right))
-            .to.be.true;
-        });
-      });
-
       describe('clear-button-visible', () => {
         let textfield;
 

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -125,6 +125,35 @@
           assertEdgesAligned('top', 'bottom');
         });
 
+        describe('right-to-left', () => {
+
+          before(() => {
+            document.body.setAttribute('dir', 'rtl');
+
+            // Workaround: The scrollbars of the document element slightly mess up the
+            // alignment calculations, but this can be reproduced only inside <iframe>
+            document.documentElement.style.overflow = 'hidden';
+          });
+
+          after(() => {
+            document.body.removeAttribute('dir');
+            document.documentElement.style.removeProperty('overflow');
+          });
+
+          it('should align by right edge', () => {
+            datepicker.open();
+            assertEdgesAligned('right', 'right');
+          });
+
+          it('should flip to align by left edge', () => {
+            datepicker.style.position = 'fixed';
+            datepicker.style.right = (window.innerWidth / 2) + 'px';
+
+            datepicker.open();
+            assertEdgesAligned('left', 'left');
+          });
+        });
+
       });
 
       describe('Sizing', () => {

--- a/test/dropdown.html
+++ b/test/dropdown.html
@@ -94,6 +94,39 @@
         });
       }
 
+      describe('alignment', () => {
+
+        function assertEdgesAligned(datepickerEdge, overlayEdge) {
+          expect(datepicker.getBoundingClientRect()[datepickerEdge]).to.equal(
+            datepicker.$.overlay.$.content.getBoundingClientRect()[overlayEdge]);
+        }
+
+        it('should align below the field, by left edge', () => {
+          datepicker.open();
+          assertEdgesAligned('left', 'left');
+          assertEdgesAligned('bottom', 'top');
+        });
+
+        it('should flip to align by right edge', () => {
+          datepicker.style.position = 'fixed';
+          datepicker.style.left = (window.innerWidth / 2) + 'px';
+
+          datepicker.open();
+          assertEdgesAligned('right', 'right');
+          assertEdgesAligned('bottom', 'top');
+        });
+
+        it('should flip to align above the field', () => {
+          datepicker.style.position = 'fixed';
+          datepicker.style.bottom = 0 + 'px';
+
+          datepicker.open();
+          assertEdgesAligned('left', 'left');
+          assertEdgesAligned('top', 'bottom');
+        });
+
+      });
+
       describe('Sizing', () => {
 
         beforeEach(() => {


### PR DESCRIPTION
Fixes #710 

Also:
- added tests for alignment without RTL
- fixed linter error

(see commit messages for more info)

Don't squash.