### PR TITLE
fix: keep invalid _inputValue during value-changed event

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -509,7 +509,9 @@ This program is available under Apache License Version 2.0, available at https:/
         this.__dispatchChange = true;
       }
       const value = this._formatISO(selectedDate);
-      this._applyInputValue(selectedDate);
+
+      this.__keepInputValue || this._applyInputValue(selectedDate);
+
       if (value !== this.value) {
         this.validate();
         this.value = value;
@@ -690,14 +692,15 @@ This program is available under Apache License Version 2.0, available at https:/
       // Select the parsed input or focused date
       this._ignoreFocusedDateChange = true;
       if (this.i18n.parseDate) {
-        var inputValue = this._inputValue || '';
+        const inputValue = this._inputValue || '';
         const parsedDate = this._getParsedDate(inputValue);
 
         if (this._isValidDate(parsedDate)) {
           this._selectedDate = parsedDate;
         } else {
+          this.__keepInputValue = true;
           this._selectedDate = null;
-          this._inputValue = inputValue;
+          this.__keepInputValue = false;
         }
       } else if (this._focusedDate) {
         this._selectedDate = this._focusedDate;

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -197,6 +197,17 @@
         datepicker.close();
       });
 
+      it('should keep invalid input value during value-changed event', done => {
+        datepicker.value = '2020-01-01';
+        inputValue('foo');
+
+        datepicker.addEventListener('value-changed', () => {
+          expect(datepicker._inputValue).to.equal('foo');
+          done();
+        });
+        datepicker.close();
+      });
+
       it('should validate keyboard input (valid)', done => {
         inputValue('01/01/2000');
 


### PR DESCRIPTION
fix #721