### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,20 @@
+export interface DatePickerDate {
+  day: number;
+  month: number;
+  year: number;
+}
+
+export interface DatePickerI18n {
+  monthNames: string[];
+  weekdays: string[];
+  weekdaysShort: string[];
+  firstDayOfWeek: number;
+  week: string;
+  calendar: string;
+  clear: string;
+  today: string;
+  cancel: string;
+  parseDate: (date: string) => DatePickerDate;
+  formatDate: (date: DatePickerDate) => string;
+  formatTitle: (monthName: string, fullYear: number) => string;
+}

--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -14,7 +14,7 @@ export interface DatePickerI18n {
   clear: string;
   today: string;
   cancel: string;
-  parseDate: (date: string) => DatePickerDate;
+  parseDate: (date: string) => DatePickerDate | undefined;
   formatDate: (date: DatePickerDate) => string;
   formatTitle: (monthName: string, fullYear: number) => string;
 }

--- a/bower.json
+++ b/bower.json
@@ -37,14 +37,14 @@
     "iron-media-query": "^2.0.0",
     "iron-resizable-behavior": "^2.0.0",
     "polymer": "^2.0.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.6.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
-    "vaadin-overlay": "vaadin/vaadin-overlay#^3.4.0",
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1",
+    "vaadin-text-field": "vaadin/vaadin-text-field#^2.7.0-alpha1",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.2.2",
+    "vaadin-overlay": "vaadin/vaadin-overlay#^3.5.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.1"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",
@@ -59,8 +59,5 @@
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0",
     "vaadin-custom-field": "vaadin/vaadin-custom-field#^1.0.0",
     "vaadin-dialog": "^2.2.1"
-  },
-  "resolutions": {
-    "vaadin-element-mixin": "^2.0.0"
   }
 }

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,21 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "src/vaadin-date-picker-helper.js",
+    "src/vaadin-date-picker-overlay-content.js",
+    "src/vaadin-date-picker-overlay.js",
+    "src/vaadin-date-picker-styles.js",
+    "src/vaadin-date-picker-text-field.js",
+    "src/vaadin-infinite-scroller.js",
+    "src/vaadin-month-calendar.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "DatePickerI18n"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,12 @@
+module.exports = {
+  files: [
+    'vaadin-date-picker.js',
+    'vaadin-date-picker-light.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/polymer.json
+++ b/polymer.json
@@ -1,5 +1,0 @@
-{
-  "lint": {
-    "ignoreWarnings": ["overriding-private"]
-  }
-}

--- a/src/vaadin-date-picker-helper.html
+++ b/src/vaadin-date-picker-helper.html
@@ -7,6 +7,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <script>
   window.Vaadin = window.Vaadin || {};
 
+  /** @private */
   Vaadin.DatePickerHelper = class VaadinDatePickerHelper {
     /**
      * Get ISO 8601 week number for the given date.

--- a/src/vaadin-date-picker-light.html
+++ b/src/vaadin-date-picker-light.html
@@ -125,12 +125,17 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              * Name of the two-way data-bindable property representing the
              * value of the custom input field.
+             * @type {string}
              */
             attrForValue: {
               type: String,
               value: 'bind-value'
             },
 
+            /**
+             * @type {boolean}
+             * @protected
+             */
             _overlayInitialized: {
               type: Boolean,
               value: true
@@ -138,6 +143,10 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /**
+         * @return {HTMLElement}
+         * @protected
+         */
         _input() {
           // Using the same selector than in combo-box.
           // TODO: revisit this to decide the selector and document conveniently.
@@ -150,6 +159,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @return {string | undefined} */
         get _inputValue() {
           return this._inputElement && this._inputElement[Polymer.CaseMap.dashToCamelCase(this.attrForValue)];
         }

--- a/src/vaadin-date-picker-light.html
+++ b/src/vaadin-date-picker-light.html
@@ -7,7 +7,6 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../iron-media-query/iron-media-query.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
-<link rel="import" href="../../vaadin-themable-mixin/vaadin-theme-property-mixin.html">
 <link rel="import" href="vaadin-date-picker-overlay.html">
 <link rel="import" href="vaadin-date-picker-overlay-content.html">
 <link rel="import" href="vaadin-date-picker-mixin.html">
@@ -109,13 +108,11 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * @memberof Vaadin
        * @mixes Vaadin.ThemableMixin
-       * @mixes Vaadin.ThemePropertyMixin
        * @mixes Vaadin.DatePickerMixin
        */
       class DatePickerLightElement extends
         Vaadin.ThemableMixin(
-          Vaadin.ThemePropertyMixin(
-            Vaadin.DatePickerMixin(Polymer.Element))) {
+          Vaadin.DatePickerMixin(Polymer.Element)) {
         static get is() {
           return 'vaadin-date-picker-light';
         }

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -22,11 +22,13 @@ This program is available under Apache License Version 2.0, available at https:/
       return {
         /**
          * The current selected date.
+         * @private
          */
         _selectedDate: {
           type: Date
         },
 
+        /** @private */
         _focusedDate: Date,
 
         /**
@@ -36,7 +38,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
          *
-         * @type {String}
+         * @type {string}
          */
         value: {
           type: String,
@@ -47,6 +49,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Set to true to mark the input as required.
+         * @type {boolean}
          */
         required: {
           type: Boolean,
@@ -96,17 +99,22 @@ This program is available under Apache License Version 2.0, available at https:/
           type: Boolean
         },
 
+        /** @private */
         _fullscreen: {
           value: false,
           observer: '_fullscreenChanged'
         },
 
+        /** @private */
         _fullscreenMediaQuery: {
           value: '(max-width: 420px), (max-height: 420px)'
         },
 
-        // An array of ancestor elements whose -webkit-overflow-scrolling is forced from value
-        // 'touch' to value 'auto' in order to prevent them from clipping the dropdown. iOS only.
+        /**
+         * An array of ancestor elements whose -webkit-overflow-scrolling is forced from value
+         * 'touch' to value 'auto' in order to prevent them from clipping the dropdown. iOS only.
+         * @private
+         */
         _touchPrevented: Array,
 
         /**
@@ -182,7 +190,7 @@ This program is available under Apache License Version 2.0, available at https:/
               }
             }
 
-         *
+         * @type {!DatePickerI18n}
          * @default {English/US}
          */
         i18n: {
@@ -242,7 +250,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
          *
-         * @type {String}
+         * @type {string | undefined}
          */
         min: {
           type: String,
@@ -256,7 +264,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * - ISO 8601 `"YYYY-MM-DD"` (default)
          * - 6-digit extended ISO 8601 `"+YYYYYY-MM-DD"`, `"-YYYYYY-MM-DD"`
          *
-         * @type {String}
+         * @type {string | undefined}
          */
         max: {
           type: String,
@@ -265,6 +273,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * The earliest date that can be selected. All earlier dates will be disabled.
+         * @type {string}
+         * @private
          */
         _minDate: {
           type: Date,
@@ -274,33 +284,41 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * The latest date that can be selected. All later dates will be disabled.
+         * @private
+         * @protected
          */
         _maxDate: {
           type: Date,
           value: ''
         },
 
+        /** @private */
         _noInput: {
           type: Boolean,
           computed: '_isNoInput(_fullscreen, _ios, i18n, i18n.*)'
         },
 
+        /** @private */
         _ios: {
           type: Boolean,
           value: navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/)
         },
 
+        /** @private */
         _webkitOverflowScroll: {
           type: Boolean,
           value: document.createElement('div').style.webkitOverflowScrolling === ''
         },
 
+        /** @private */
         _ignoreAnnounce: {
           value: true
         },
 
+        /** @private */
         _focusOverlayOnOpen: Boolean,
 
+        /** @protected */
         _overlayInitialized: Boolean
       };
     }
@@ -314,6 +332,7 @@ This program is available under Apache License Version 2.0, available at https:/
       ];
     }
 
+    /** @protected */
     ready() {
       super.ready();
       this._boundOnScroll = this._onScroll.bind(this);
@@ -366,6 +385,7 @@ This program is available under Apache License Version 2.0, available at https:/
       });
     }
 
+    /** @private */
     _initOverlay() {
       this.$.overlay.removeAttribute('disable-upgrade');
       this._overlayInitialized = true;
@@ -393,9 +413,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('touchstart', bringToFrontListener);
     }
 
-    /**
-     * @protected
-     */
+    /** @protected */
     disconnectedCallback() {
       super.disconnectedCallback();
 
@@ -415,6 +433,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _close(e) {
       if (e) {
         e.stopPropagation();
@@ -432,10 +451,15 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /**
+     * @return {HTMLElement}
+     * @protected
+     */
     get _inputElement() {
       return this._input();
     }
 
+    /** @private */
     get _nativeInput() {
       if (this._inputElement) {
         // vaadin-text-field's input is focusElement
@@ -446,6 +470,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _parseDate(str) {
       // Parsing with RegExp to ensure correct format
       var parts = /^([-+]\d{1}|\d{2,4}|[-+]\d{6})-(\d{1,2})-(\d{1,2})$/.exec(str);
@@ -460,10 +485,12 @@ This program is available under Apache License Version 2.0, available at https:/
       return date;
     }
 
+    /** @private */
     _isNoInput(fullscreen, ios, i18n) {
       return !this._inputElement || fullscreen || ios || !i18n.parseDate;
     }
 
+    /** @private */
     _formatISO(date) {
       if (!(date instanceof Date)) {
         return '';
@@ -489,6 +516,7 @@ This program is available under Apache License Version 2.0, available at https:/
       return [year, month, day].join('-');
     }
 
+    /** @private */
     _openedChanged(opened) {
       if (opened && !this._overlayInitialized) {
         this._initOverlay();
@@ -501,6 +529,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _selectedDateChanged(selectedDate, formatDate) {
       if (selectedDate === undefined || formatDate === undefined) {
         return;
@@ -523,6 +552,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._ignoreFocusedDateChange = false;
     }
 
+    /** @private */
     _focusedDateChanged(focusedDate, formatDate) {
       if (focusedDate === undefined || formatDate === undefined) {
         return;
@@ -533,6 +563,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _updateHasValue(value) {
       if (value) {
         this.setAttribute('has-value', '');
@@ -541,13 +572,14 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-
+    /** @private */
     __getOverlayTheme(theme, overlayInitialized) {
       if (overlayInitialized) {
         return theme;
       }
     }
 
+    /** @private */
     _handleDateChange(property, value, oldValue) {
       if (!value) {
         this[property] = '';
@@ -565,6 +597,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _valueChanged(value, oldValue) {
       if (this.__dispatchChange) {
         this.dispatchEvent(new CustomEvent('change', {bubbles: true}));
@@ -572,14 +605,17 @@ This program is available under Apache License Version 2.0, available at https:/
       this._handleDateChange('_selectedDate', value, oldValue);
     }
 
+    /** @private */
     _minChanged(value, oldValue) {
       this._handleDateChange('_minDate', value, oldValue);
     }
 
+    /** @private */
     _maxChanged(value, oldValue) {
       this._handleDateChange('_maxDate', value, oldValue);
     }
 
+    /** @private */
     _updateAlignmentAndPosition() {
       if (!this._overlayInitialized) {
         return;
@@ -619,12 +655,14 @@ This program is available under Apache License Version 2.0, available at https:/
       this._overlayContent._repositionYearScroller();
     }
 
+    /** @private */
     _fullscreenChanged() {
       if (this._overlayInitialized && this.$.overlay.opened) {
         this._updateAlignmentAndPosition();
       }
     }
 
+    /** @private */
     _onOverlayOpened() {
       this._openedWithFocusRing = this.hasAttribute('focus-ring') || (this.focusElement && this.focusElement.hasAttribute('focus-ring'));
 
@@ -672,6 +710,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     // A hack needed for iOS to prevent dropdown from being clipped in an
     // ancestor container with -webkit-overflow-scrolling: touch;
+    /** @private */
     _preventWebkitOverflowScrollingTouch(element) {
       var result = [];
       while (element) {
@@ -688,6 +727,7 @@ This program is available under Apache License Version 2.0, available at https:/
       return result;
     }
 
+    /** @private */
     _selectParsedOrFocusedDate() {
       // Select the parsed input or focused date
       this._ignoreFocusedDateChange = true;
@@ -708,6 +748,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._ignoreFocusedDateChange = false;
     }
 
+    /** @private */
     _onOverlayClosed() {
       this._ignoreAnnounce = true;
 
@@ -777,12 +818,14 @@ This program is available under Apache License Version 2.0, available at https:/
       return inputValid && minMaxValid && inputValidity;
     }
 
+    /** @private */
     _onScroll(e) {
       if (e.target === window || !this._overlayContent.contains(e.target)) {
         this._updateAlignmentAndPosition();
       }
     }
 
+    /** @protected */
     _focus() {
       if (this._noInput) {
         this._overlayInitialized && this._overlayContent.focus();
@@ -791,19 +834,23 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _focusAndSelect() {
       this._focus();
       this._setSelectionRange(0, this._inputValue.length);
     }
 
+    /** @private */
     _applyInputValue(date) {
       this._inputValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
     }
 
+    /** @private */
     _getFormattedDate(formatDate, date) {
       return formatDate(Vaadin.DatePickerHelper._extractDateParts(date));
     }
 
+    /** @private */
     _setSelectionRange(a, b) {
       if (this._nativeInput && this._nativeInput.setSelectionRange) {
         this._nativeInput.setSelectionRange(a, b);
@@ -812,6 +859,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     /**
      * Keyboard Navigation
+     * @private
      */
     _eventKey(e) {
       var keys = ['down', 'up', 'enter', 'esc', 'tab'];
@@ -824,10 +872,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _isValidDate(d) {
       return d && !isNaN(d.getTime());
     }
 
+    /** @private */
     _onKeydown(e) {
       if (this._noInput) {
         // The input element cannot be readonly as it would conflict with
@@ -909,6 +959,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _getParsedDate(inputValue = this._inputValue) {
       const dateObject = this.i18n.parseDate && this.i18n.parseDate(inputValue);
       const parsedDate = dateObject &&
@@ -916,6 +967,7 @@ This program is available under Apache License Version 2.0, available at https:/
       return parsedDate;
     }
 
+    /** @private */
     _onUserInput(e) {
       if (!this.opened && this._inputElement.value && !this.autoOpenDisabled) {
         this.open();
@@ -930,6 +982,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _userInputValueChanged(value) {
       if (this.opened && this._inputValue) {
         const parsedDate = this._getParsedDate();
@@ -944,12 +997,14 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    /** @private */
     _announceFocusedDate(_focusedDate, opened, _ignoreAnnounce) {
       if (opened && !_ignoreAnnounce) {
         this._overlayContent.announceFocusedDate();
       }
     }
 
+    /** @private */
     get _overlayContent() {
       return this.$.overlay.content.querySelector('#overlay-content');
     }

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -22,13 +22,17 @@ This program is available under Apache License Version 2.0, available at https:/
       return {
         /**
          * The current selected date.
-         * @private
+         * @type {Date | undefined}
+         * @protected
          */
         _selectedDate: {
           type: Date
         },
 
-        /** @private */
+        /**
+         * @type {Date | undefined}
+         * @protected
+         */
         _focusedDate: Date,
 
         /**
@@ -99,13 +103,19 @@ This program is available under Apache License Version 2.0, available at https:/
           type: Boolean
         },
 
-        /** @private */
+        /**
+         * @type {boolean}
+         * @protected
+         */
         _fullscreen: {
           value: false,
           observer: '_fullscreenChanged'
         },
 
-        /** @private */
+        /**
+         * @type {string}
+         * @protected
+         */
         _fullscreenMediaQuery: {
           value: '(max-width: 420px), (max-height: 420px)'
         },
@@ -273,8 +283,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * The earliest date that can be selected. All earlier dates will be disabled.
-         * @type {string}
-         * @private
+         * @type {Date | string}
+         * @protected
          */
         _minDate: {
           type: Date,
@@ -284,7 +294,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * The latest date that can be selected. All later dates will be disabled.
-         * @private
+         * @type {Date | string}
          * @protected
          */
         _maxDate: {
@@ -662,7 +672,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    /** @private */
+    /** @protected */
     _onOverlayOpened() {
       this._openedWithFocusRing = this.hasAttribute('focus-ring') || (this.focusElement && this.focusElement.hasAttribute('focus-ring'));
 
@@ -748,7 +758,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._ignoreFocusedDateChange = false;
     }
 
-    /** @private */
+    /** @protected */
     _onOverlayClosed() {
       this._ignoreAnnounce = true;
 
@@ -778,7 +788,7 @@ This program is available under Apache License Version 2.0, available at https:/
     /**
      * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
      *
-     * @param {string} value Value to validate. Optional, defaults to user's input value.
+     * @param {string=} value Value to validate. Optional, defaults to user's input value.
      * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
      */
     validate() {
@@ -793,7 +803,7 @@ This program is available under Apache License Version 2.0, available at https:/
      *
      * Override the `checkValidity` method for custom validations.
      *
-     * @param {string} value Value to validate. Optional, defaults to the selected date.
+     * @param {string=} value Value to validate. Optional, defaults to the selected date.
      * @return {boolean} True if the value is valid
      */
     checkValidity() {

--- a/src/vaadin-date-picker-overlay-content.html
+++ b/src/vaadin-date-picker-overlay-content.html
@@ -11,7 +11,6 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../iron-a11y-announcer/iron-a11y-announcer.html">
 <link rel="import" href="../../vaadin-button/src/vaadin-button.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
-<link rel="import" href="../../vaadin-themable-mixin/vaadin-theme-property-mixin.html">
 <link rel="import" href="../../vaadin-element-mixin/vaadin-dir-mixin.html">
 <link rel="import" href="vaadin-month-calendar.html">
 <link rel="import" href="vaadin-infinite-scroller.html">
@@ -218,9 +217,8 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       class DatePickerOverlayContentElement extends
         Vaadin.ThemableMixin(
-          Vaadin.ThemePropertyMixin(
-            Vaadin.DirMixin(
-              Polymer.GestureEventListeners(Polymer.Element)))) {
+          Vaadin.DirMixin(
+            Polymer.GestureEventListeners(Polymer.Element))) {
         static get is() {
           return 'vaadin-date-picker-overlay-content';
         }

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -8,7 +8,6 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../../polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../../iron-media-query/iron-media-query.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
-<link rel="import" href="../../vaadin-themable-mixin/vaadin-theme-property-mixin.html">
 <link rel="import" href="../../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 <link rel="import" href="vaadin-date-picker-overlay.html">
 <link rel="import" href="vaadin-date-picker-overlay-content.html">
@@ -170,7 +169,6 @@ This program is available under Apache License Version 2.0, available at https:/
        * @mixes Vaadin.ElementMixin
        * @mixes Vaadin.ControlStateMixin
        * @mixes Vaadin.ThemableMixin
-       * @mixes Vaadin.ThemePropertyMixin
        * @mixes Vaadin.DatePickerMixin
        * @mixes Polymer.GestureEventListeners
        * @demo demo/index.html
@@ -179,9 +177,8 @@ This program is available under Apache License Version 2.0, available at https:/
         Vaadin.ElementMixin(
           Vaadin.ControlStateMixin(
             Vaadin.ThemableMixin(
-              Vaadin.ThemePropertyMixin(
-                Vaadin.DatePickerMixin(
-                  Polymer.GestureEventListeners(Polymer.Element)))))) {
+              Vaadin.DatePickerMixin(
+                Polymer.GestureEventListeners(Polymer.Element))))) {
 
         static get is() {
           return 'vaadin-date-picker';
@@ -195,6 +192,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * Set to true to display the clear icon which clears the input.
+             * @type {boolean}
              */
             clearButtonVisible: {
               type: Boolean,
@@ -203,6 +201,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to disable this element.
+             * @type {boolean}
              */
             disabled: {
               type: Boolean,
@@ -222,6 +221,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to make this element read-only.
+             * @type {boolean}
              */
             readonly: {
               type: Boolean,
@@ -231,6 +231,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * This property is set to true when the control value invalid.
+             * @type {boolean}
              */
             invalid: {
               type: Boolean,
@@ -239,6 +240,7 @@ This program is available under Apache License Version 2.0, available at https:/
               value: false
             },
 
+            /** @private */
             _userInputValue: String
           };
         }
@@ -250,6 +252,7 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @protected */
         ready() {
           super.ready();
 
@@ -265,6 +268,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _onVaadinOverlayClose(e) {
           if (this._openedWithFocusRing && this.hasAttribute('focused')) {
             this.focusElement.setAttribute('focus-ring', '');
@@ -276,11 +280,16 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _toggle(e) {
           e.stopPropagation();
           this[(this._overlayInitialized && this.$.overlay.opened) ? 'close' : 'open']();
         }
 
+        /**
+         * @return {HTMLElement}
+         * @protected
+         */
         _input() {
           return this.$.input;
         }
@@ -289,21 +298,26 @@ This program is available under Apache License Version 2.0, available at https:/
           this._inputElement.value = value;
         }
 
+        /** @return {string} */
         get _inputValue() {
           return this._inputElement.value;
         }
 
+        /** @private */
         _getAriaExpanded(opened) {
           return Boolean(opened).toString();
         }
 
         /**
-         * Focussable element used by vaadin-control-state-mixin
+         * Focusable element used by vaadin-control-state-mixin
+         * @return {!HTMLElement}
+         * @protected
          */
         get focusElement() {
           return this._input() || this;
         }
 
+        /** @private */
         _setClearButtonLabel(i18nClear) {
           // FIXME(platosha): expose i18n API in <vaadin-text-field>
           // https://github.com/vaadin/vaadin-text-field/issues/348


### PR DESCRIPTION
Fixes #714 

Generated TS definitions look like this:

### `vaadin-date-picker-light.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ThemePropertyMixin} from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';

import {DatePickerMixin} from './vaadin-date-picker-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {dashToCamelCase} from '@polymer/polymer/lib/utils/case-map.js';

declare class DatePickerLightElement extends
  ThemableMixin(
  ThemePropertyMixin(
  DatePickerMixin(
  PolymerElement))) {
  _overlayInitialized: boolean;
  _inputValue: string|undefined;
  attrForValue: string;
  _input(): HTMLElement|null;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-date-picker-light": DatePickerLightElement;
  }
}

export {DatePickerLightElement};
```

### `vaadin-date-picker-mixin.d.ts`

```ts
import {IronA11yKeysBehavior} from '@polymer/iron-a11y-keys-behavior/iron-a11y-keys-behavior.js';

import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';

import {addListener} from '@polymer/polymer/lib/utils/gestures.js';

import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';

export {DatePickerMixin};

declare function DatePickerMixin<T extends new (...args: any[]) => {}>(base: T): T & DatePickerMixinConstructor;

interface DatePickerMixinConstructor {
  new(...args: any[]): DatePickerMixin;
}

export {DatePickerMixinConstructor};

interface DatePickerMixin {
  readonly _inputElement: HTMLElement|null;
  value: string;
  required: boolean;
  name: string|null|undefined;
  initialPosition: string|null|undefined;
  label: string|null|undefined;
  opened: boolean|null|undefined;
  autoOpenDisabled: boolean|null|undefined;
  showWeekNumbers: boolean|null|undefined;
  i18n: DatePickerI18n;
  min: string|undefined;
  max: string|undefined;
  _overlayInitialized: boolean|null|undefined;
  ready(): void;
  disconnectedCallback(): void;
  open(): void;
  close(): void;
  validate(): boolean;
  checkValidity(): boolean;
  _focus(): void;
}

import {DatePickerI18n} from '../@types/interfaces';
```

### `vaadin-date-picker.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {GestureEventListeners} from '@polymer/polymer/lib/mixins/gesture-event-listeners.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ControlStateMixin} from '@vaadin/vaadin-control-state-mixin/vaadin-control-state-mixin.js';

import {DatePickerMixin} from './vaadin-date-picker-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';

declare class DatePickerElement extends
  ElementMixin(
  ControlStateMixin(
  ThemableMixin(
  DatePickerMixin(
  GestureEventListeners(
  PolymerElement))))) {
  readonly focusElement: HTMLElement;
  disabled: boolean;
  _inputValue: string;
  clearButtonVisible: boolean;
  errorMessage: string|null|undefined;
  placeholder: string|null|undefined;
  readonly: boolean;
  invalid: boolean;
  ready(): void;
  _input(): HTMLElement|null;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-date-picker": DatePickerElement;
  }
}

export {DatePickerElement};
```