### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-date-picker-light.html
+++ b/src/vaadin-date-picker-light.html
@@ -122,6 +122,7 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              * Name of the two-way data-bindable property representing the
              * value of the custom input field.
+             * @attr {string} attr-for-value
              * @type {string}
              */
             attrForValue: {

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -71,6 +71,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * Date which should be visible when there is no value selected.
          *
          * The same date formats as for the `value` property are supported.
+         * @attr {string} initial-position
          */
         initialPosition: String,
 
@@ -91,6 +92,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Set true to prevent the overlay from opening automatically.
+         * @attr {boolean} auto-open-disabled
          */
         autoOpenDisabled: Boolean,
 
@@ -98,6 +100,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * Set true to display ISO-8601 week numbers in the calendar. Notice that
          * displaying week numbers is only supported when `i18n.firstDayOfWeek`
          * is 1 (Monday).
+         * @attr {boolean} show-week-numbers
          */
         showWeekNumbers: {
           type: Boolean

--- a/src/vaadin-date-picker.html
+++ b/src/vaadin-date-picker.html
@@ -192,6 +192,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * Set to true to display the clear icon which clears the input.
+             * @attr {boolean} clear-button-visible
              * @type {boolean}
              */
             clearButtonVisible: {
@@ -211,6 +212,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The error message to display when the input is invalid.
+             * @attr {string} error-message
              */
             errorMessage: String,
 


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `4.3` branch. When cherry-picking it to master, we would need to add attribute for `helperText`.