### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -22,17 +22,17 @@ export interface DatePickerI18n {
 /**
  * Fired when the `opened` property changes.
  */
-export type DatePickerOpenedChanged = CustomEvent<{ value: boolean; path: 'opened' }>;
+export type DatePickerOpenedChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `invalid` property changes.
  */
-export type DatePickerInvalidChanged = CustomEvent<{ value: boolean; path: 'invalid' }>;
+export type DatePickerInvalidChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type DatePickerValueChanged = CustomEvent<{ value: string; path: 'value' }>;
+export type DatePickerValueChanged = CustomEvent<{ value: string }>;
 
 export interface DatePickerElementEventMap {
   'opened-changed': DatePickerOpenedChanged;

--- a/src/vaadin-date-picker-light.d.ts
+++ b/src/vaadin-date-picker-light.d.ts
@@ -38,6 +38,9 @@ import { DatePickerEventMap } from './interfaces';
  *
  * Note: the `theme` attribute value set on `<vaadin-date-picker-light>`
  * is propagated to the internal themable components listed above.
+ *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class DatePickerLightElement extends ThemableMixin(DatePickerMixin(HTMLElement)) {
   _overlayInitialized: boolean;

--- a/src/vaadin-date-picker-light.js
+++ b/src/vaadin-date-picker-light.js
@@ -46,6 +46,9 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * Note: the `theme` attribute value set on `<vaadin-date-picker-light>`
  * is propagated to the internal themable components listed above.
  *
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ *
  * @extends HTMLElement
  * @mixes ThemableMixin
  * @mixes DatePickerMixin

--- a/src/vaadin-date-picker.d.ts
+++ b/src/vaadin-date-picker.d.ts
@@ -80,6 +80,10 @@ import { DatePickerEventMap } from './interfaces';
  *
  * Note: the `theme` attribute value set on `<vaadin-date-picker>` is
  * propagated to the internal themable components listed above.
+ *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class DatePickerElement extends ElementMixin(
   ControlStateMixin(ThemableMixin(DatePickerMixin(GestureEventListeners(HTMLElement))))

--- a/src/vaadin-date-picker.js
+++ b/src/vaadin-date-picker.js
@@ -96,7 +96,6 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
  * @mixes ThemableMixin
  * @mixes DatePickerMixin
  * @mixes GestureEventListeners
- * @demo demo/index.html
  */
 class DatePickerElement extends ElementMixin(
   ControlStateMixin(ThemableMixin(DatePickerMixin(GestureEventListeners(PolymerElement))))

--- a/src/vaadin-date-picker.js
+++ b/src/vaadin-date-picker.js
@@ -86,6 +86,10 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
  * Note: the `theme` attribute value set on `<vaadin-date-picker>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ControlStateMixin


### PR DESCRIPTION
1. Added `@fires` annotations to enable VS Code lit-plugin code completion support.
2. Removed `@demo` annotation as the demo has been removed.
3. Removed `path` from events typings as Polymer-specific and generally unused.