### PR TITLE
refactor: cleanup IE11 vendor prefixes

### DIFF
--- a/src/vaadin-date-picker-overlay-content.js
+++ b/src/vaadin-date-picker-overlay-content.js
@@ -103,7 +103,6 @@ class DatePickerOverlayContentElement extends ThemableMixin(DirMixin(GestureEven
           -webkit-tap-highlight-color: transparent;
           -webkit-user-select: none;
           -moz-user-select: none;
-          -ms-user-select: none;
           user-select: none;
           /* Center the year scroller position. */
           --vaadin-infinite-scroller-buffer-offset: 50%;

--- a/src/vaadin-date-picker-text-field.js
+++ b/src/vaadin-date-picker-text-field.js
@@ -22,12 +22,6 @@ registerStyles(
       direction: rtl;
       text-align: left;
     }
-
-    :host([dir='rtl']) [part='value']:-ms-input-placeholder,
-    :host([dir='rtl']) [part='input-field'] ::slotted(input):-ms-input-placeholder {
-      direction: rtl;
-      text-align: left;
-    }
   `,
   { moduleId: 'vaadin-date-picker-text-field-styles' }
 );

--- a/src/vaadin-infinite-scroller.js
+++ b/src/vaadin-infinite-scroller.js
@@ -30,7 +30,6 @@ class InfiniteScrollerElement extends PolymerElement {
           outline: none;
           margin-right: -40px;
           -webkit-overflow-scrolling: touch;
-          -ms-overflow-style: none;
           overflow-x: hidden;
         }
 

--- a/theme/lumo/vaadin-month-calendar-styles.js
+++ b/theme/lumo/vaadin-month-calendar-styles.js
@@ -10,7 +10,6 @@ registerStyles(
   css`
     :host {
       -moz-user-select: none;
-      -ms-user-select: none;
       -webkit-user-select: none;
       -webkit-tap-highlight-color: transparent;
       user-select: none;


### PR DESCRIPTION
We no longer support IE11 and legacy Edge so let's remove `-ms` vendor prefixes.