### PR TITLE
chore: align JSDoc, add missing events [skip ci]

### DIFF
--- a/src/vaadin-date-picker-light.d.ts
+++ b/src/vaadin-date-picker-light.d.ts
@@ -39,6 +39,7 @@ import { DatePickerEventMap } from './interfaces';
  * Note: the `theme` attribute value set on `<vaadin-date-picker-light>`
  * is propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-date-picker-light.js
+++ b/src/vaadin-date-picker-light.js
@@ -46,6 +46,7 @@ import { DatePickerMixin } from './vaadin-date-picker-mixin.js';
  * Note: the `theme` attribute value set on `<vaadin-date-picker-light>`
  * is propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *

--- a/src/vaadin-date-picker-mixin.js
+++ b/src/vaadin-date-picker-mixin.js
@@ -1036,4 +1036,16 @@ export const DatePickerMixin = (subclass) =>
      *
      * @event change
      */
+
+    /**
+     * Fired when `value` property value changes.
+     *
+     * @event value-changed
+     */
+
+    /**
+     * Fired when `opened` property value changes.
+     *
+     * @event opened-changed
+     */
   };

--- a/src/vaadin-date-picker.d.ts
+++ b/src/vaadin-date-picker.d.ts
@@ -81,6 +81,7 @@ import { DatePickerEventMap } from './interfaces';
  * Note: the `theme` attribute value set on `<vaadin-date-picker>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/src/vaadin-date-picker.js
+++ b/src/vaadin-date-picker.js
@@ -86,6 +86,7 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
  * Note: the `theme` attribute value set on `<vaadin-date-picker>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.


### PR DESCRIPTION
This PR aligns the event names provided by `lit-plugin` and API docs:

- Added `@event` JSDoc annotations for two events missing from the [API docs](https://cdn.vaadin.com/vaadin-date-picker/5.0.0-alpha1/#/elements/vaadin-date-picker#events)
- Added `@fires` JSDoc annotation for missing `change` event.