### PR TITLE
test: refactor and cleanup test helpers

### DIFF
--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -138,9 +138,9 @@ describe('basic features', () => {
 
   it('should close on overlay date tap', async () => {
     await open(datepicker);
+    const spy = sinon.spy(datepicker, 'close');
     getOverlayContent(datepicker).dispatchEvent(new CustomEvent('date-tap', { bubbles: true, composed: true }));
-    await aTimeout(1);
-    expect(datepicker.opened).to.be.false;
+    expect(spy.called).to.be.true;
   });
 
   it('should not have label defined by default', () => {
@@ -236,7 +236,6 @@ describe('basic features', () => {
       const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
       await close(datepicker);
       window.dispatchEvent(new CustomEvent('scroll'));
-      await aTimeout(1);
       expect(spy.called).to.be.false;
     });
   });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { fixtureSync, nextFrame } from '@open-wc/testing-helpers';
+import { aTimeout, fixtureSync, nextFrame } from '@open-wc/testing-helpers';
 import './not-animated-styles.js';
 import '../vaadin-date-picker.js';
 import { click, close, getOverlayContent, ios, monthsEqual, open, listenForEvent, tap } from './common.js';
@@ -48,43 +48,26 @@ describe('basic features', () => {
     expect(spy.called).to.be.true;
   });
 
-  it('should blur when datepicker is opened on fullscreen', (done) => {
+  it('should blur when datepicker is opened on fullscreen', async () => {
     datepicker._fullscreen = true;
-
     const spy = sinon.spy(datepicker.focusElement, 'blur');
-
-    open(datepicker, () => {
-      expect(spy.called).to.be.true;
-      done();
-    });
+    await open(datepicker);
+    expect(spy.called).to.be.true;
   });
 
-  it('should notify opened changed on open', (done) => {
-    open(datepicker, () => {
-      expect(datepicker.opened).to.be.true;
-      done();
-    });
+  it('should notify opened changed on open and close', async () => {
+    const spy = sinon.spy();
+    datepicker.addEventListener('opened-changed', spy);
+    await open(datepicker);
+    expect(spy.calledOnce).to.be.true;
+    await close(datepicker);
+    expect(spy.calledTwice).to.be.true;
   });
 
-  it('should notify opened changed on close', (done) => {
-    open(datepicker, () => {
-      listenForEvent(datepicker, 'opened-changed', () => {
-        expect(datepicker.opened).to.be.false;
-        done();
-      });
-      datepicker.close();
-    });
-  });
-
-  it('should close with close call', (done) => {
-    open(datepicker, () => {
-      close(datepicker, () => {
-        setTimeout(() => {
-          expect(datepicker.opened).to.be.false;
-          done();
-        }, 1);
-      });
-    });
+  it('should set opened to false with close call', async () => {
+    await open(datepicker);
+    await close(datepicker);
+    expect(datepicker.opened).to.be.false;
   });
 
   it('should open on input tap', (done) => {
@@ -108,26 +91,22 @@ describe('basic features', () => {
     expect(datepicker.$.input.placeholder).to.be.equal(placeholder);
   });
 
-  it('should scroll to today by default', (done) => {
+  it('should scroll to today by default', async () => {
     const overlayContent = getOverlayContent(datepicker);
     const spy = sinon.spy(overlayContent, 'scrollToDate');
-    open(datepicker, () => {
-      expect(monthsEqual(spy.firstCall.args[0], new Date())).to.be.true;
-      done();
-    });
+    await open(datepicker);
+    expect(monthsEqual(spy.firstCall.args[0], new Date())).to.be.true;
   });
 
-  it('should scroll to initial position', (done) => {
+  it('should scroll to initial position', async () => {
     datepicker.initialPosition = '2016-01-01';
     const initialPositionDate = new Date(2016, 0, 1);
 
     const overlayContent = getOverlayContent(datepicker);
     const spy = sinon.spy(overlayContent, 'scrollToDate');
 
-    open(datepicker, () => {
-      expect(spy.firstCall.args[0]).to.eql(initialPositionDate);
-      done();
-    });
+    await open(datepicker);
+    expect(spy.firstCall.args[0]).to.eql(initialPositionDate);
   });
 
   it('should remember the original initial position on reopen', (done) => {
@@ -149,21 +128,19 @@ describe('basic features', () => {
     });
   });
 
-  it('should scroll to selected value by default', (done) => {
+  it('should scroll to selected value by default', async () => {
     const overlayContent = getOverlayContent(datepicker);
     const spy = sinon.spy(overlayContent, 'scrollToDate');
     datepicker.value = '2000-02-01';
-    open(datepicker, () => {
-      expect(monthsEqual(spy.firstCall.args[0], new Date(2000, 1, 1))).to.be.true;
-      done();
-    });
+    await open(datepicker);
+    expect(monthsEqual(spy.firstCall.args[0], new Date(2000, 1, 1))).to.be.true;
   });
 
-  it('should close on overlay date tap', (done) => {
-    open(datepicker, () => {
-      getOverlayContent(datepicker).dispatchEvent(new CustomEvent('date-tap', { bubbles: true, composed: true }));
-    });
-    listenForEvent(datepicker.$.overlay, 'vaadin-overlay-close', done);
+  it('should close on overlay date tap', async () => {
+    await open(datepicker);
+    getOverlayContent(datepicker).dispatchEvent(new CustomEvent('date-tap', { bubbles: true, composed: true }));
+    await aTimeout(1);
+    expect(datepicker.opened).to.be.false;
   });
 
   it('should not have label defined by default', () => {
@@ -200,26 +177,19 @@ describe('basic features', () => {
     listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', done);
   });
 
-  it('should scroll to a date on open', (done) => {
+  it('should scroll to a date on open', async () => {
     const overlayContent = getOverlayContent(datepicker);
     // We must scroll to a date on every open because at least IE11 seems to reset
     // scrollTop while the dropdown is closed. This will result in all kind of problems.
     const spy = sinon.spy(overlayContent, 'scrollToDate');
 
-    open(datepicker, () => {
-      expect(spy.called).to.be.true;
-
-      spy.resetHistory();
-      close(datepicker, () => {
-        setTimeout(() => {
-          open(datepicker, () => {
-            expect(spy.called).to.be.true;
-            done();
-          });
-        }, 1);
-      });
-      datepicker.close();
-    });
+    await open(datepicker);
+    expect(spy.called).to.be.true;
+    spy.resetHistory();
+    await close(datepicker);
+    await aTimeout(1);
+    await open(datepicker);
+    expect(spy.called).to.be.true;
   });
 
   it('should not change datepicker width', () => {
@@ -232,58 +202,42 @@ describe('basic features', () => {
     expect(datepicker.clientWidth).to.equal(width);
   });
 
-  it('should realign on iron-resize', (done) => {
-    sinon.stub(datepicker, '_boundUpdateAlignmentAndPosition').callsFake(() => {
-      if (!done._called) {
-        done._called = true;
-        done();
-      }
-    });
-    open(datepicker, () => {
-      datepicker.dispatchEvent(new CustomEvent('iron-resize', { bubbles: false }));
-    });
-  });
-
   it('should set has-value attribute when value is set', () => {
     datepicker.value = '2000-02-01';
     expect(datepicker.hasAttribute('has-value')).to.be.true;
   });
 
-  describe('window scroll realign', () => {
-    beforeEach((done) => {
-      open(datepicker, done);
+  describe('realign', () => {
+    beforeEach(async () => {
+      await open(datepicker);
     });
 
-    it('should realign on window scroll', (done) => {
-      sinon.stub(datepicker, '_updateAlignmentAndPosition').callsFake(() => {
-        if (!done._called) {
-          done._called = true;
-          done();
-        }
-      });
+    it('should realign on iron-resize', async () => {
+      const spy = sinon.spy(datepicker._overlayContent, '_repositionYearScroller');
+      datepicker.dispatchEvent(new CustomEvent('iron-resize', { bubbles: false }));
+      expect(spy.called).to.be.true;
+    });
+
+    it('should realign on window scroll', () => {
+      const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
       window.dispatchEvent(new CustomEvent('scroll'));
+      expect(spy.called).to.be.true;
     });
 
     // https://github.com/vaadin/vaadin-date-picker/issues/330
-    (ios ? it.skip : it)('should not realign on year/month scroll', (done) => {
+    (ios ? it.skip : it)('should not realign on year/month scroll', async () => {
       const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
       getOverlayContent(datepicker).$.yearScroller.$.scroller.scrollTop += 100;
-      setTimeout(() => {
-        expect(spy.called).to.be.false;
-        done();
-      }, 1);
+      await aTimeout(1);
+      expect(spy.called).to.be.false;
     });
 
-    it('should not realign once closed', (done) => {
-      datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-        const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
-        window.dispatchEvent(new CustomEvent('scroll'));
-        setTimeout(() => {
-          expect(spy.called).to.be.false;
-          done();
-        }, 1);
-      });
-      datepicker.close();
+    it('should not realign once closed', async () => {
+      const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
+      await close(datepicker);
+      window.dispatchEvent(new CustomEvent('scroll'));
+      await aTimeout(1);
+      expect(spy.called).to.be.false;
     });
   });
 
@@ -345,7 +299,7 @@ describe('basic features', () => {
 
   describe('i18n', () => {
     let overlayContent, clearButton;
-    beforeEach((done) => {
+    beforeEach(async () => {
       clearButton = datepicker._inputElement.shadowRoot.querySelector('[part="clear-button"]');
       datepicker.set('i18n.weekdays', 'sunnuntai_maanantai_tiistai_keskiviikko_torstai_perjantai_lauantai'.split('_'));
       datepicker.set('i18n.weekdaysShort', 'su_ma_ti_ke_to_pe_la'.split('_'));
@@ -363,11 +317,10 @@ describe('basic features', () => {
       overlayContent = getOverlayContent(datepicker);
       overlayContent.$.monthScroller.bufferSize = 1;
 
-      open(datepicker, () => {
-        overlayContent.$.monthScroller._finishInit();
-        overlayContent.$.yearScroller._finishInit();
-        setTimeout(done, 1);
-      });
+      await open(datepicker);
+      overlayContent.$.monthScroller._finishInit();
+      overlayContent.$.yearScroller._finishInit();
+      await aTimeout(1);
     });
 
     it('should notify i18n mutation to children', () => {
@@ -644,19 +597,14 @@ describe('wrapped', () => {
     datepicker = container.querySelector('vaadin-date-picker');
   });
 
-  it('should realign on container scroll', (done) => {
-    open(datepicker, () => {
-      sinon.stub(datepicker, '_updateAlignmentAndPosition').callsFake(() => {
-        if (!done._called) {
-          done._called = true;
-          done();
-        }
-      });
-      container.scrollTop += 100;
-    });
+  it('should realign on container scroll', async () => {
+    const spy = sinon.spy(datepicker, '_updateAlignmentAndPosition');
+    await open(datepicker);
+    container.scrollTop += 100;
+    expect(spy.called).to.be.true;
   });
 
-  it.only('should match the parent width', () => {
+  it('should match the parent width', () => {
     container.querySelector('div').style.width = '120px';
     datepicker.style.width = '100%';
     expect(datepicker.$.input.clientWidth).to.equal(120);

--- a/test/common.js
+++ b/test/common.js
@@ -114,33 +114,3 @@ export function getOverlayContent(datepicker) {
   overlayContent.$.yearScroller.bufferSize = 0;
   return overlayContent;
 }
-
-// TODO: validate if the statement below is still valid when running in GitHub actions.
-// FF and Chrome are unable to focus input/button when tests are run in the headless window manager used in Travis
-function monkeyPatchNativeFocus() {
-  customElements.whenDefined('vaadin-text-field').then(() => {
-    const TextFieldElement = customElements.get('vaadin-text-field');
-    TextFieldElement.prototype.focus = function () {
-      this._setFocused(true);
-    };
-    TextFieldElement.prototype.blur = function () {
-      this._setFocused(false);
-    };
-  });
-
-  customElements.whenDefined('vaadin-button').then(() => {
-    const ButtonElement = customElements.get('vaadin-button');
-    ButtonElement.prototype.focus = function () {
-      this._setFocused(true);
-    };
-  });
-
-  customElements.whenDefined('vaadin-date-picker').then(() => {
-    const DatePickerElement = customElements.get('vaadin-date-picker');
-    DatePickerElement.prototype.blur = function () {
-      this._inputElement._setFocused(false);
-    };
-  });
-}
-
-window.addEventListener('WebComponentsReady', monkeyPatchNativeFocus);

--- a/test/common.js
+++ b/test/common.js
@@ -56,14 +56,18 @@ export function listenForEvent(elem, type, callback) {
   elem.addEventListener(type, listener);
 }
 
-export function open(datepicker, callback) {
-  listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', callback);
-  datepicker.open();
+export function open(datepicker) {
+  return new Promise((resolve) => {
+    listenForEvent(datepicker.$.overlay, 'vaadin-overlay-open', resolve);
+    datepicker.open();
+  });
 }
 
-export function close(datepicker, callback) {
-  listenForEvent(datepicker.$.overlay, 'vaadin-overlay-close', callback);
-  datepicker.close();
+export function close(datepicker) {
+  return new Promise((resolve) => {
+    listenForEvent(datepicker.$.overlay, 'vaadin-overlay-close', resolve);
+    datepicker.close();
+  });
 }
 
 export function tap(element) {

--- a/test/custom-input.test.js
+++ b/test/custom-input.test.js
@@ -65,13 +65,11 @@ describe('custom input', () => {
     });
 
     describe('in content', () => {
-      beforeEach((done) => {
+      beforeEach(async () => {
         overlayContent.$.monthScroller.bufferSize = 1;
-        open(datepicker, () => {
-          overlayContent.$.yearScroller._finishInit();
-          overlayContent.$.monthScroller._finishInit();
-          done();
-        });
+        await open(datepicker);
+        overlayContent.$.yearScroller._finishInit();
+        overlayContent.$.monthScroller._finishInit();
       });
 
       it('should propagate theme attribute to month calendar', () => {

--- a/test/form-input.test.js
+++ b/test/form-input.test.js
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { aTimeout, fixture, html } from '@open-wc/testing-helpers';
 import './not-animated-styles.js';
+import { close, open } from './common.js';
 import { DatePickerElement } from '../vaadin-date-picker.js';
 
 class DatePicker2016Element extends DatePickerElement {
@@ -76,19 +77,14 @@ describe('form input', () => {
       expect(datepicker._inputElement.invalid).to.be.true;
     });
 
-    it('should re-validate old input after selecting date', (done) => {
+    it('should re-validate old input after selecting date', async () => {
       // Set invalid value.
       inputValue('foo');
       expect(datepicker.validate()).to.equal(false);
-
-      datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-        expect(datepicker.invalid).to.equal(false);
-        done();
-      });
-
-      datepicker.open();
+      await open(datepicker);
       datepicker.value = '2000-02-01';
-      datepicker.close();
+      await close(datepicker);
+      expect(datepicker.invalid).to.equal(false);
     });
 
     it('should set proper validity by the time the value-changed event is fired', (done) => {
@@ -121,15 +117,11 @@ describe('form input', () => {
       expect(datepicker._inputElement.disabled).to.equal(true);
     });
 
-    it('should validate keyboard input (invalid)', (done) => {
+    it('should validate keyboard input (invalid)', async () => {
       inputValue('foo');
-
-      datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-        expect(datepicker.validate()).to.equal(false);
-        expect(datepicker.invalid).to.be.equal(true);
-        done();
-      });
-      datepicker.close();
+      await close(datepicker);
+      expect(datepicker.validate()).to.equal(false);
+      expect(datepicker.invalid).to.be.equal(true);
     });
 
     it('should keep invalid input value during value-changed event', (done) => {
@@ -143,27 +135,19 @@ describe('form input', () => {
       datepicker.close();
     });
 
-    it('should validate keyboard input (valid)', (done) => {
+    it('should validate keyboard input (valid)', async () => {
       inputValue('01/01/2000');
-
-      datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-        expect(datepicker.validate()).to.equal(true);
-        expect(datepicker.invalid).to.be.equal(false);
-        done();
-      });
-      datepicker.close();
+      await close(datepicker);
+      expect(datepicker.validate()).to.equal(true);
+      expect(datepicker.invalid).to.be.equal(false);
     });
 
-    it('should validate keyboard input (disallowed value)', (done) => {
+    it('should validate keyboard input (disallowed value)', async () => {
       datepicker.min = '2001-01-01';
       inputValue('01/01/2000');
-
-      datepicker.$.overlay.addEventListener('vaadin-overlay-close', () => {
-        expect(datepicker.validate()).to.equal(false);
-        expect(datepicker.invalid).to.be.equal(true);
-        done();
-      });
-      datepicker.close();
+      await close(datepicker);
+      expect(datepicker.validate()).to.equal(false);
+      expect(datepicker.invalid).to.be.equal(true);
     });
   });
 

--- a/test/keyboard-navigation.test.js
+++ b/test/keyboard-navigation.test.js
@@ -111,16 +111,14 @@ import { getDefaultI18n, getOverlayContent, ios, listenForEvent, open } from './
       expect(focusedDate(datepicker)).to.eql(new Date(2001, 0, 2));
     });
 
-    it('should be focused on initial position when no value is set', (done) => {
+    it('should be focused on initial position when no value is set', async () => {
       datepicker.value = null;
       datepicker.initialPosition = '2001-01-01';
 
-      open(datepicker, () => {
-        target = getOverlayContent(datepicker);
-        arrowRight();
-        expect(focusedDate(datepicker)).to.eql(new Date(2001, 0, 2));
-        done();
-      });
+      await open(datepicker);
+      target = getOverlayContent(datepicker);
+      arrowRight();
+      expect(focusedDate(datepicker)).to.eql(new Date(2001, 0, 2));
     });
 
     it('should be focused on today if no initial position is set', () => {

--- a/test/theme-propagation.test.js
+++ b/test/theme-propagation.test.js
@@ -32,15 +32,13 @@ describe('theme attribute', () => {
   describe('in content', () => {
     let overlayContent;
 
-    beforeEach((done) => {
-      open(datepicker, () => {
-        overlayContent = datepicker.$.overlay.content.querySelector('#overlay-content');
-        overlayContent.$.yearScroller.bufferSize = 0;
-        overlayContent.$.monthScroller.bufferSize = 1;
-        overlayContent.$.yearScroller._finishInit();
-        overlayContent.$.monthScroller._finishInit();
-        done();
-      });
+    beforeEach(async () => {
+      await open(datepicker);
+      overlayContent = datepicker.$.overlay.content.querySelector('#overlay-content');
+      overlayContent.$.yearScroller.bufferSize = 0;
+      overlayContent.$.monthScroller.bufferSize = 1;
+      overlayContent.$.yearScroller._finishInit();
+      overlayContent.$.monthScroller._finishInit();
     });
 
     it('should propagate theme attribute to month calendar', () => {

--- a/test/wai-aria.test.js
+++ b/test/wai-aria.test.js
@@ -345,20 +345,15 @@ describe('WAI-ARIA', () => {
     });
 
     if (!ios) {
-      it('should announce once', (done) => {
+      it('should announce once', async () => {
         datepicker._focusedDate = new Date(2016, 1, 1);
-
-        open(datepicker, () => {
-          const announceSpy = sinon.spy();
-          document.body.addEventListener('iron-announce', announceSpy);
-          datepicker._focusedDate = new Date(2016, 1, 2);
-
-          setTimeout(() => {
-            expect(announceSpy.callCount).to.be.equal(1);
-            document.body.removeEventListener('iron-announce', announceSpy);
-            done();
-          }, 1);
-        });
+        await open(datepicker);
+        const announceSpy = sinon.spy();
+        document.body.addEventListener('iron-announce', announceSpy);
+        datepicker._focusedDate = new Date(2016, 1, 2);
+        await aTimeout(1);
+        expect(announceSpy.callCount).to.be.equal(1);
+        document.body.removeEventListener('iron-announce', announceSpy);
       });
     }
 


### PR DESCRIPTION
- updated `open` and `close` test helpers to return a Promise to make some tests use `async` / `await`
- removed the no longer used hacks related to the focus monkey patching (tests pass without those)
- tried to get rid of using `setTimeout` in few places where it doesn't seem to be really needed
- fixed `it.only` committed by accident 🙈  will consider adding a ESLint plugin to prevent that in future.