### PR TITLE
Add aria-level to divs with heading roles

### DIFF
--- a/src/vaadin-month-calendar.js
+++ b/src/vaadin-month-calendar.js
@@ -58,7 +58,7 @@ class MonthCalendarElement extends ThemableMixin(GestureEventListeners(PolymerEl
         }
       </style>
 
-      <div part="month-header" role="heading">[[_getTitle(month, i18n.monthNames)]]</div>
+      <div part="month-header" role="heading" aria-level="2">[[_getTitle(month, i18n.monthNames)]]</div>
       <div id="monthGrid" on-tap="_handleTap" on-touchend="_preventDefault" on-touchstart="_onMonthGridTouchStart">
         <div id="weekdays-container">
           <div hidden$="[[!_showWeekSeparator(showWeekNumbers, i18n.firstDayOfWeek)]]" part="weekday"></div>
@@ -67,14 +67,16 @@ class MonthCalendarElement extends ThemableMixin(GestureEventListeners(PolymerEl
               is="dom-repeat"
               items="[[_getWeekDayNames(i18n.weekdays, i18n.weekdaysShort, showWeekNumbers, i18n.firstDayOfWeek)]]"
             >
-              <div part="weekday" role="heading" aria-label$="[[item.weekDay]]">[[item.weekDayShort]]</div>
+              <div part="weekday" role="heading" aria-level="2" aria-label$="[[item.weekDay]]">
+                [[item.weekDayShort]]
+              </div>
             </template>
           </div>
         </div>
         <div id="days-container">
           <div part="week-numbers" hidden$="[[!_showWeekSeparator(showWeekNumbers, i18n.firstDayOfWeek)]]">
             <template is="dom-repeat" items="[[_getWeekNumbers(_days)]]">
-              <div part="week-number" role="heading" aria-label$="[[i18n.week]] [[item]]">[[item]]</div>
+              <div part="week-number" role="heading" aria-level="2" aria-label$="[[i18n.week]] [[item]]">[[item]]</div>
             </template>
           </div>
           <div id="days">

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -326,7 +326,9 @@ describe('basic features', () => {
       const monthCalendar = overlayContent.$.monthScroller.querySelector('vaadin-month-calendar');
       const weekdays = monthCalendar.$.monthGrid.querySelectorAll('[part="weekday"]:not(:empty)');
       const weekdayLabels = Array.prototype.map.call(weekdays, (weekday) => weekday.getAttribute('aria-label'));
-      const weekdayTitles = Array.prototype.map.call(weekdays, (weekday) => weekday.textContent);
+      const weekdayTitles = Array.prototype.map.call(weekdays, (weekday) =>
+        weekday.textContent.replaceAll(/(\r?\n|\r)|( )/g, '')
+      );
       expect(weekdayLabels).to.eql([
         'maanantai',
         'tiistai',

--- a/test/month-calendar.test.js
+++ b/test/month-calendar.test.js
@@ -40,7 +40,7 @@ describe('vaadin-month-calendar', () => {
 
   it('should render days in correct order by default', () => {
     const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent);
+    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.replaceAll(/(\r?\n|\r)|( )/g, ''));
     expect(weekdayTitles).to.eql(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']);
   });
 
@@ -48,7 +48,7 @@ describe('vaadin-month-calendar', () => {
     monthCalendar.set('i18n.firstDayOfWeek', 1); // Start from Monday.
     await aTimeout();
     const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent);
+    const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent.replaceAll(/(\r?\n|\r)|( )/g, ''));
     expect(weekdayTitles).to.eql(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
   });
 
@@ -169,7 +169,9 @@ describe('vaadin-month-calendar', () => {
 
     it('should render weekdays in correct locale', () => {
       const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
-      const weekdayTitles = Array.from(weekdays).map((weekday) => weekday.textContent);
+      const weekdayTitles = Array.from(weekdays).map((weekday) =>
+        weekday.textContent.replaceAll(/(\r?\n|\r)|( )/g, '')
+      );
       const weekdayLabels = Array.from(weekdays).map((weekday) => weekday.getAttribute('aria-label'));
       expect(weekdayLabels).to.eql([
         'maanantai',

--- a/test/wai-aria.test.js
+++ b/test/wai-aria.test.js
@@ -157,11 +157,24 @@ describe('WAI-ARIA', () => {
       expect(monthCalendar.shadowRoot.querySelector('[part="month-header"]').getAttribute('role')).to.equal('heading');
     });
 
+    it('should have an aria-level on the title', () => {
+      // Consistency and convenience. Announces title as a header.
+      expect(monthCalendar.shadowRoot.querySelector('[part="month-header"]').getAttribute('aria-level')).to.equal('2');
+    });
+
     it('should have heading roles on the weekdays', () => {
       // iOS VoiceOver bug: visible text is spoken instead of aria-label otherwise.
       const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
       Array.from(weekdays).forEach((weekday) => {
         expect(weekday.getAttribute('role')).to.equal('heading');
+      });
+    });
+
+    it('should have an aria-level on the weekdays', () => {
+      // iOS VoiceOver bug: visible text is spoken instead of aria-label otherwise.
+      const weekdays = monthCalendar.shadowRoot.querySelectorAll('[part="weekday"]:not(:empty)');
+      Array.from(weekdays).forEach((weekday) => {
+        expect(weekday.getAttribute('aria-level')).to.equal('2');
       });
     });
 
@@ -236,6 +249,15 @@ describe('WAI-ARIA', () => {
 
         Array.from(weekNumberElements).forEach((weekNumberElement) => {
           expect(weekNumberElement.getAttribute('role')).to.equal('heading');
+        });
+      });
+
+      it('should have an aria-level on week numbers', () => {
+        // iOS VoiceOver bug: visible text is spoken instead of aria-label otherwise.
+        const weekNumberElements = monthCalendar.shadowRoot.querySelectorAll('[part="week-number"]');
+
+        Array.from(weekNumberElements).forEach((weekNumberElement) => {
+          expect(weekNumberElement.getAttribute('aria-level')).to.equal('2');
         });
       });
 


### PR DESCRIPTION
Currently, `vaadin-date-picker` has three divs with `role="heading"`. This attribute needs, concurrently, an `aria-level` reference. This is described in the [W3C WAI-ARIA 1.1 Required States and Properties](https://www.w3.org/TR/wai-aria-1.1/#heading).

To fix this a11y issue I added an `aria-level="2"`, which is the default value of this attribute.