### PR TITLE
Fix role grid month calendar

### DIFF
--- a/src/vaadin-month-calendar.html
+++ b/src/vaadin-month-calendar.html
@@ -55,10 +55,16 @@ This program is available under Apache License Version 2.0, available at https:/
     </style>
 
     <div part="month-header" role="heading">[[_getTitle(month, i18n.monthNames)]]</div>
-    <div id="monthGrid" on-tap="_handleTap" on-touchend="_preventDefault" on-touchstart="_onMonthGridTouchStart">
+    <div
+         id="monthGrid"
+         on-tap="_handleTap"
+         on-touchend="_preventDefault"
+         on-touchstart="_onMonthGridTouchStart"
+         role="grid"
+    >
       <div id="weekdays-container">
         <div hidden="[[!_showWeekSeparator(showWeekNumbers, i18n.firstDayOfWeek)]]" part="weekday"></div>
-        <div part="weekdays">
+        <div part="weekdays" role="rowheader">
           <template is="dom-repeat" items="[[_getWeekDayNames(i18n.weekdays, i18n.weekdaysShort, showWeekNumbers, i18n.firstDayOfWeek)]]">
             <div part="weekday" role="heading" aria-label$="[[item.weekDay]]">[[item.weekDayShort]]</div>
           </template>
@@ -70,7 +76,7 @@ This program is available under Apache License Version 2.0, available at https:/
             <div part="week-number" role="heading" aria-label$="[[i18n.week]] [[item]]">[[item]]</div>
           </template>
         </div>
-        <div id="days">
+        <div id="days" role="rowgroup">
           <template is="dom-repeat" items="[[_days]]">
             <div
                 part="date"

--- a/test/month-calendar.html
+++ b/test/month-calendar.html
@@ -187,6 +187,17 @@
         });
       });
 
+      it('should have the appropriate roles set ', () => {
+        const monthRole = monthCalendar.$.monthGrid.getAttribute('role');
+        expect(monthRole).to.be.equal('grid');
+
+        const weekdaysRole = monthCalendar.shadowRoot.querySelector('[part="weekdays"]').getAttribute('role');
+        expect(weekdaysRole).to.be.equal('rowheader');
+
+        const daysRole = monthCalendar.$.days.getAttribute('role');
+        expect(daysRole).to.be.equal('rowgroup');
+      });
+
       describe('i18n', () => {
         beforeEach(done => {
           monthCalendar.i18n = {


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Screen reader users are getting confused about the structure of each month section, in the calendar widget.

This change introduces roles in key divs that aim to better describe the markdown to screen reader users.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.