### PR TITLE
fix: prevent initial validation for date-picker when no constraints

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -636,7 +636,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       if (!Vaadin.DatePickerHelper._dateEquals(this[property], date)) {
         this[property] = date;
-        this.value && this.validate();
+        this.value && oldValue !== undefined && this.validate();
       }
     }
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "rules": {
     "no-undef": 0,
     "no-unused-vars": 0

--- a/test/common.js
+++ b/test/common.js
@@ -125,4 +125,11 @@ function monkeyPatchNativeFocus() {
   });
 }
 
+async function nextRender(element) {
+  return new Promise(resolve => {
+    Polymer.RenderStatus.afterNextRender(element, resolve);
+  });
+}
+
+
 window.addEventListener('WebComponentsReady', monkeyPatchNativeFocus);

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -103,6 +103,50 @@
         });
       });
 
+      describe('initial', () => {
+        let validateSpy;
+
+        beforeEach(() => {
+          datePicker = document.createElement('vaadin-date-picker');
+          validateSpy = sinon.spy(datePicker, 'validate');
+        });
+
+        afterEach(() => {
+          datePicker.remove();
+        });
+
+        it('should not validate by default', async() => {
+          document.body.appendChild(datePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate when the field has an initial value', async() => {
+          datePicker.value = '2020-01-01';
+          document.body.appendChild(datePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate when the field has an initial value and invalid', async() => {
+          datePicker.value = '2020-01-01';
+          datePicker.invalid = true;
+          document.body.appendChild(datePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate on min change when no value is provided', () => {
+          datePicker.min = '2020-01-01';
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate on max change when no value is provided', () => {
+          datePicker.max = '2020-01-01';
+          expect(validateSpy.called).to.be.false;
+        });
+      });
+
       describe('custom validator', () => {
         beforeEach(done => {
           datepicker = fixture('custom-validation');


### PR DESCRIPTION
Backports web-components#4169 as part of an EoD task

Part of https://github.com/vaadin/web-components/issues/5763

> ## Description
> The PR prevents the initial validation that could previously take place when `date-picker` was initially provided with a non-empty value and no constraints were specified.
> 
> Part of #4150
> 
> ## Type of change
> * [x]  Bugfix
> 
> ## Checklist
> * [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
> * [x]  I have added a description following the guideline.
> * [x]  The issue is created in the corresponding repository and I have referenced it.
> * [x]  I have added tests to ensure my change is effective and works as intended.
> * [x]  New and existing tests are passing locally with my change.
> * [x]  I have performed self-review and corrected misspellings.

