### PR TITLE
fix: reset _hasInputValue on programmatic input change (CP:14)

### DIFF
--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -334,7 +334,11 @@ This program is available under Apache License Version 2.0, available at https:/
         },
 
         /**
-         * When true, the input element has a non-empty value entered by the user.
+         * The property indicates true only if the input has been entered by the user.
+         * In the case of programmatic changes, the property is reset to false.
+         * Read more about why this workaround is needed:
+         * https://github.com/vaadin/web-components/issues/5639
+         *
          * @protected
          */
         _hasInputValue: {
@@ -851,13 +855,19 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /**
-     * The input element's value.
+     * The setter resets the `_hasInputValue` property
+     * to false when the input element's value is updated programmatically.
+     * In date-picker, `_hasInputValue` is supposed to indicate true only
+     * if the input has been entered by the user.
+     * Read more about why this workaround is needed:
+     * https://github.com/vaadin/web-components/issues/5639
      *
      * @protected
      */
     set _inputElementValue(value) {
       if (this._inputElement) {
         this._inputElement[this._inputElementValueProperty] = value;
+        this._hasInputValue = false;
       }
     }
 
@@ -954,9 +964,6 @@ This program is available under Apache License Version 2.0, available at https:/
     /** @private */
     _applyInputValue(date) {
       this._inputElementValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
-      // It is no longer input entered by the user,
-      // so reset the `hasInputValue` property.
-      this._hasInputValue = false;
     }
 
     /** @private */

--- a/src/vaadin-date-picker-mixin.html
+++ b/src/vaadin-date-picker-mixin.html
@@ -954,6 +954,9 @@ This program is available under Apache License Version 2.0, available at https:/
     /** @private */
     _applyInputValue(date) {
       this._inputElementValue = date ? this._getFormattedDate(this.i18n.formatDate, date) : '';
+      // It is no longer input entered by the user,
+      // so reset the `hasInputValue` property.
+      this._hasInputValue = false;
     }
 
     /** @private */

--- a/test/events.html
+++ b/test/events.html
@@ -8,6 +8,7 @@
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-picker.html">
+  <script src="common.js"></script>
 </head>
 
 <body>
@@ -80,7 +81,7 @@
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
           });
 
-          it('should be fired when selecting a date with Space', async() => {
+          (ios ? it.skip : it)('should be fired when selecting a date with Space', async() => {
             arrowDown(input);
             space(datePicker._overlayContent);
             expect(valueChangedSpy.calledOnce).to.be.true;

--- a/test/events.html
+++ b/test/events.html
@@ -69,7 +69,7 @@
 
           it('should be fired when clearing the user input with Esc', async() => {
             esc(input);
-            expect(datePicker._inputElement.value).to.be.empty;
+            expect(input.value).to.be.empty;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
           });
 
@@ -106,7 +106,7 @@
 
           it('should be fired on clear button click', () => {
             clearButton.click();
-            expect(datePicker._inputElement.value).to.be.empty;
+            expect(input.value).to.be.empty;
             expect(valueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
@@ -114,7 +114,7 @@
 
           it('should be fired when reverting the user input to the value with Esc', async() => {
             esc(datePicker._overlayContent);
-            expect(datePicker._inputElement.value).to.equal('1/1/2022');
+            expect(input.value).to.equal('1/1/2022');
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
           });
         });

--- a/test/events.html
+++ b/test/events.html
@@ -7,49 +7,98 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-picker.html">
+  <link rel="import" href="helpers.html">
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 </head>
 
 <body>
-  <test-fixture id="date-picker">
+  <test-fixture id="datepicker-clear-button-visible">
     <template>
-      <vaadin-date-picker></vaadin-date-picker>
+      <vaadin-date-picker clear-button-visible></vaadin-date-picker>
     </template>
   </test-fixture>
   <script>
-    describe('events', () => {
-      let datePicker, input;
+  describe('events', () => {
 
-      describe('has-input-value-changed event', () => {
-        beforeEach(async() => {
-          datePicker = fixture('date-picker');
-          input = datePicker._inputElement;
-        });
+    describe('has-input-value-changed event', () => {
+      beforeEach(async() => {
+        hasInputValueChangedSpy = sinon.spy();
+        valueChangedSpy = sinon.spy();
+        datePicker = fixture('datepicker-clear-button-visible');
+        input = datePicker._inputElement;
+        clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
+        datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+        datePicker.addEventListener('value-changed', valueChangedSpy);
+        input.focus();
+      });
 
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = '2000-02-01';
-          input.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+      describe('without value', () => {
+        describe('with user input', () => {
+          beforeEach(async() => {
+            type('1/1/2022', input);
+            hasInputValueChangedSpy.reset();
+            // valueChangedSpy.reset();
+          });
 
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-        });
+          it('should be fired when clearing the user input with Esc', async() => {
+            pressEsc(input);
+            expect(datePicker._inputElement.value).to.be.empty;
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          });
 
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = '2000-02-01';
-          input.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
-          hasInputValueChangedSpy.reset();
+          it('should be fired when comitting the user input with Enter', async() => {
+            // pressEnter(input);
+            MockInteractions.pressEnter(input);
+            expect(valueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
 
-          input.value = '2000-02-20';
-          input.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+          it('should be fired when selecting a date with Space', async() => {
+            // Move focus inside the dropdown to the typed date.
+            pressArrowDown(input);
+            pressSpace(input);
+            // expect(valueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
+
+      describe('with value', () => {
+        beforeEach(async() => {
+          type('1/1/2022', input);
+          // pressEnter(input);
+          MockInteractions.pressEnter(input);
+          valueChangedSpy.reset();
+          hasInputValueChangedSpy.reset();
+        });
+
+        describe('with user input', () => {
+          beforeEach(async() => {
+            type('foo', input);
+            hasInputValueChangedSpy.reset();
+          });
+
+          it('should be fired on clear button click', () => {
+            clearButton.click();
+            expect(datePicker._inputElement.value).to.be.empty;
+            expect(valueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+
+          /* it('should be fired when reverting the user input to the value with Esc', async () => {
+            	expect(datePicker._inputElement.value).to.equal('1/1/2022foo');
+            	pressEsc(input);
+                expect(datePicker._inputElement.value).to.equal('1/1/2022');
+                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+              }); */
+        });
+      });
+
+  
     });
+  });
   </script>
 </body>

--- a/test/events.html
+++ b/test/events.html
@@ -18,112 +18,109 @@
     </template>
   </test-fixture>
   <script>
-    // iOS doesn't support arrow keys etc.
-    if (!ios) {
-      describe('events', () => {
+    (ios ? describe.skip : describe)('events', () => {
     
-        function inputChar(char, target) {
-          target.value += char;
-          MockInteractions.keyDownOn(target, char.charCodeAt(0));
-          target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+      function inputChar(target, char) {
+        target.value += char;
+        MockInteractions.keyDownOn(target, char.charCodeAt(0));
+        target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+      }
+    
+      function inputText(target, text) {
+        for (var i = 0; i < text.length; i++) {
+          inputChar(target, text[i]);
         }
+      }
     
-        function inputText(target, text) {
-          for (var i = 0; i < text.length; i++) {
-            inputChar(text[i], target);
-          }
-        }
+      function arrowDown(target) {
+        MockInteractions.keyDownOn(target, 40);
+      }
     
-        function arrowDown(target) {
-          MockInteractions.keyDownOn(target, 40);
-        }
+      function enter(target) {
+        MockInteractions.pressEnter(target);
+      }
     
-        function enter(target) {
-          MockInteractions.pressEnter(target);
-        }
+      function space(target) {
+        MockInteractions.pressSpace(target);
+      }
     
-        function space(target) {
-          MockInteractions.pressSpace(target);
-        }
+      function esc(target) {
+        MockInteractions.keyDownOn(target, 27, null, 'Escape');
+      }
     
-        function esc(target) {
-          MockInteractions.keyDownOn(target, 27, null, 'Escape');
-        }
+      describe('has-input-value-changed event', () => {
+        let input, datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
     
-        describe('has-input-value-changed event', () => {
-          let input, datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
+        beforeEach(async() => {
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
+          datePicker = fixture('date-picker');
+          input = datePicker._inputElement;
+          clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
+          datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+          datePicker.addEventListener('value-changed', valueChangedSpy);
+        });
     
-          beforeEach(async() => {
-            hasInputValueChangedSpy = sinon.spy();
-            valueChangedSpy = sinon.spy();
-            datePicker = fixture('date-picker');
-            input = datePicker._inputElement;
-            clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
-            datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-            datePicker.addEventListener('value-changed', valueChangedSpy);
-          });
-    
-          describe('without value', () => {
-            describe('with user input', () => {
-              beforeEach(async() => {
-                inputText(input, '1/1/2022');
-                hasInputValueChangedSpy.reset();
-              });
-    
-              it('should be fired when clearing the user input with Esc', async() => {
-                esc(input);
-                expect(input.value).to.be.empty;
-                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-              });
-    
-              it('should be fired when comitting the user input with Enter', async() => {
-                enter(input);
-                expect(valueChangedSpy.calledOnce).to.be.true;
-                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-                expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-              });
-    
-              it('should be fired when selecting a date with Space', async() => {
-                arrowDown(input);
-                space(datePicker._overlayContent);
-                expect(valueChangedSpy.calledOnce).to.be.true;
-                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-                expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-              });
-            });
-          });
-    
-          describe('with value', () => {
+        describe('without value', () => {
+          describe('with user input', () => {
             beforeEach(async() => {
               inputText(input, '1/1/2022');
-              enter(input);
-              valueChangedSpy.reset();
               hasInputValueChangedSpy.reset();
             });
     
-            describe('with user input', () => {
-              beforeEach(async() => {
-                inputText(input, 'foo');
-                hasInputValueChangedSpy.reset();
-              });
+            it('should be fired when clearing the user input with Esc', async() => {
+              esc(input);
+              expect(input.value).to.be.empty;
+              expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            });
     
-              it('should be fired on clear button click', () => {
-                clearButton.click();
-                expect(input.value).to.be.empty;
-                expect(valueChangedSpy.calledOnce).to.be.true;
-                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-                expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-              });
+            it('should be fired when comitting the user input with Enter', async() => {
+              enter(input);
+              expect(valueChangedSpy.calledOnce).to.be.true;
+              expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+              expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+            });
     
-              it('should be fired when reverting the user input to the value with Esc', async() => {
-                esc(datePicker._overlayContent);
-                expect(input.value).to.equal('1/1/2022');
-                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-              });
+            it('should be fired when selecting a date with Space', async() => {
+              arrowDown(input);
+              space(datePicker._overlayContent);
+              expect(valueChangedSpy.calledOnce).to.be.true;
+              expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+              expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+            });
+          });
+        });
+    
+        describe('with value', () => {
+          beforeEach(async() => {
+            inputText(input, '1/1/2022');
+            enter(input);
+            valueChangedSpy.reset();
+            hasInputValueChangedSpy.reset();
+          });
+    
+          describe('with user input', () => {
+            beforeEach(async() => {
+              inputText(input, 'foo');
+              hasInputValueChangedSpy.reset();
+            });
+    
+            it('should be fired on clear button click', () => {
+              clearButton.click();
+              expect(input.value).to.be.empty;
+              expect(valueChangedSpy.calledOnce).to.be.true;
+              expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+              expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+            });
+    
+            it('should be fired when reverting the user input to the value with Esc', async() => {
+              esc(datePicker._overlayContent);
+              expect(input.value).to.equal('1/1/2022');
+              expect(hasInputValueChangedSpy.calledOnce).to.be.true;
             });
           });
         });
       });
-    }
+    });
   </script>
 </body>

--- a/test/events.html
+++ b/test/events.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <test-fixture id="datepicker">
+  <test-fixture id="date-picker">
     <template>
       <vaadin-date-picker clear-button-visible></vaadin-date-picker>
     </template>
@@ -19,45 +19,43 @@
   <script>
   describe('events', () => {
 
-    var target;
-
-    function inputChar(char) {
+    function inputChar(char, target) {
       target.value += char;
       MockInteractions.keyDownOn(target, char.charCodeAt(0));
       target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
     }
 
-    function inputText(text) {
+    function inputText(text, target) {
       for (var i = 0; i < text.length; i++) {
-        inputChar(text[i]);
+        inputChar(text[i], target);
       }
     }
 
-    function arrowDown() {
+    function arrowDown(target) {
       MockInteractions.keyDownOn(target, 40);
     }
   
-    function enter() {
+    function enter(target) {
       MockInteractions.pressEnter(target);
     }
 
-    function space() {
+    function space(target) {
       MockInteractions.pressSpace(target);
     }
 
-    function esc() {
+    function esc(target) {
       MockInteractions.keyDownOn(target, 27, null, 'Escape');
     }
 
     describe('has-input-value-changed event', () => {
-      let datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
+      let input, datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
   
       beforeEach(async() => {
         hasInputValueChangedSpy = sinon.spy();
         valueChangedSpy = sinon.spy();
-        datePicker = fixture('datepicker');
-        target = datePicker._inputElement;
-        clearButton = target.shadowRoot.querySelector('[part="clear-button"]');
+        datePicker = fixture('date-picker');
+        input = datePicker._inputElement;
+        clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
         datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
         datePicker.addEventListener('value-changed', valueChangedSpy);
       });
@@ -65,27 +63,26 @@
       describe('without value', () => {
         describe('with user input', () => {
           beforeEach(async() => {
-            inputText('1/1/2022');
+            inputText('1/1/2022', input);
             hasInputValueChangedSpy.reset();
           });
 
           it('should be fired when clearing the user input with Esc', async() => {
-            esc();
+            esc(input);
             expect(datePicker._inputElement.value).to.be.empty;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
           });
 
           it('should be fired when comitting the user input with Enter', async() => {
-            enter();
+            enter(input);
             expect(valueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
           });
 
           it('should be fired when selecting a date with Space', async() => {
-            arrowDown();
-            target = datePicker._overlayContent;
-            space();
+            arrowDown(input);
+            space(datePicker._overlayContent);
             expect(valueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
@@ -95,15 +92,15 @@
 
       describe('with value', () => {
         beforeEach(async() => {
-          inputText('1/1/2022');
-          enter();
+          inputText('1/1/2022', input);
+          enter(input);
           valueChangedSpy.reset();
           hasInputValueChangedSpy.reset();
         });
 
         describe('with user input', () => {
           beforeEach(async() => {
-            inputText('foo');
+            inputText('foo', input);
             hasInputValueChangedSpy.reset();
           });
 
@@ -116,8 +113,7 @@
           });
 
           it('should be fired when reverting the user input to the value with Esc', async() => {
-            target = datePicker._overlayContent;
-            esc();
+            esc(datePicker._overlayContent);
             expect(datePicker._inputElement.value).to.equal('1/1/2022');
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
           });

--- a/test/events.html
+++ b/test/events.html
@@ -18,109 +18,112 @@
     </template>
   </test-fixture>
   <script>
-  describe('events', () => {
-
-    function inputChar(char, target) {
-      target.value += char;
-      MockInteractions.keyDownOn(target, char.charCodeAt(0));
-      target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
-    }
-
-    function inputText(target, text) {
-      for (var i = 0; i < text.length; i++) {
-        inputChar(text[i], target);
-      }
-    }
-
-    function arrowDown(target) {
-      MockInteractions.keyDownOn(target, 40);
-    }
-  
-    function enter(target) {
-      MockInteractions.pressEnter(target);
-    }
-
-    function space(target) {
-      MockInteractions.pressSpace(target);
-    }
-
-    function esc(target) {
-      MockInteractions.keyDownOn(target, 27, null, 'Escape');
-    }
-
-    describe('has-input-value-changed event', () => {
-      let input, datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
-  
-      beforeEach(async() => {
-        hasInputValueChangedSpy = sinon.spy();
-        valueChangedSpy = sinon.spy();
-        datePicker = fixture('date-picker');
-        input = datePicker._inputElement;
-        clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
-        datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-        datePicker.addEventListener('value-changed', valueChangedSpy);
-      });
-
-      describe('without value', () => {
-        describe('with user input', () => {
+    // iOS doesn't support arrow keys etc.
+    if (!ios) {
+      describe('events', () => {
+    
+        function inputChar(char, target) {
+          target.value += char;
+          MockInteractions.keyDownOn(target, char.charCodeAt(0));
+          target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+        }
+    
+        function inputText(target, text) {
+          for (var i = 0; i < text.length; i++) {
+            inputChar(text[i], target);
+          }
+        }
+    
+        function arrowDown(target) {
+          MockInteractions.keyDownOn(target, 40);
+        }
+    
+        function enter(target) {
+          MockInteractions.pressEnter(target);
+        }
+    
+        function space(target) {
+          MockInteractions.pressSpace(target);
+        }
+    
+        function esc(target) {
+          MockInteractions.keyDownOn(target, 27, null, 'Escape');
+        }
+    
+        describe('has-input-value-changed event', () => {
+          let input, datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
+    
           beforeEach(async() => {
-            inputText(input, '1/1/2022');
-            hasInputValueChangedSpy.reset();
+            hasInputValueChangedSpy = sinon.spy();
+            valueChangedSpy = sinon.spy();
+            datePicker = fixture('date-picker');
+            input = datePicker._inputElement;
+            clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
+            datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+            datePicker.addEventListener('value-changed', valueChangedSpy);
           });
-
-          it('should be fired when clearing the user input with Esc', async() => {
-            esc(input);
-            expect(input.value).to.be.empty;
-            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+    
+          describe('without value', () => {
+            describe('with user input', () => {
+              beforeEach(async() => {
+                inputText(input, '1/1/2022');
+                hasInputValueChangedSpy.reset();
+              });
+    
+              it('should be fired when clearing the user input with Esc', async() => {
+                esc(input);
+                expect(input.value).to.be.empty;
+                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+              });
+    
+              it('should be fired when comitting the user input with Enter', async() => {
+                enter(input);
+                expect(valueChangedSpy.calledOnce).to.be.true;
+                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+                expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+              });
+    
+              it('should be fired when selecting a date with Space', async() => {
+                arrowDown(input);
+                space(datePicker._overlayContent);
+                expect(valueChangedSpy.calledOnce).to.be.true;
+                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+                expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+              });
+            });
           });
-
-          it('should be fired when comitting the user input with Enter', async() => {
-            enter(input);
-            expect(valueChangedSpy.calledOnce).to.be.true;
-            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-          });
-
-          (ios ? it.skip : it)('should be fired when selecting a date with Space', async() => {
-            arrowDown(input);
-            space(datePicker._overlayContent);
-            expect(valueChangedSpy.calledOnce).to.be.true;
-            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+    
+          describe('with value', () => {
+            beforeEach(async() => {
+              inputText(input, '1/1/2022');
+              enter(input);
+              valueChangedSpy.reset();
+              hasInputValueChangedSpy.reset();
+            });
+    
+            describe('with user input', () => {
+              beforeEach(async() => {
+                inputText(input, 'foo');
+                hasInputValueChangedSpy.reset();
+              });
+    
+              it('should be fired on clear button click', () => {
+                clearButton.click();
+                expect(input.value).to.be.empty;
+                expect(valueChangedSpy.calledOnce).to.be.true;
+                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+                expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+              });
+    
+              it('should be fired when reverting the user input to the value with Esc', async() => {
+                esc(datePicker._overlayContent);
+                expect(input.value).to.equal('1/1/2022');
+                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+              });
+            });
           });
         });
       });
-
-      describe('with value', () => {
-        beforeEach(async() => {
-          inputText(input, '1/1/2022');
-          enter(input);
-          valueChangedSpy.reset();
-          hasInputValueChangedSpy.reset();
-        });
-
-        describe('with user input', () => {
-          beforeEach(async() => {
-            inputText(input, 'foo');
-            hasInputValueChangedSpy.reset();
-          });
-
-          it('should be fired on clear button click', () => {
-            clearButton.click();
-            expect(input.value).to.be.empty;
-            expect(valueChangedSpy.calledOnce).to.be.true;
-            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
-          });
-
-          it('should be fired when reverting the user input to the value with Esc', async() => {
-            esc(datePicker._overlayContent);
-            expect(input.value).to.equal('1/1/2022');
-            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-          });
-        });
-      });
-    });
-  });
+    }
   </script>
 </body>

--- a/test/events.html
+++ b/test/events.html
@@ -25,7 +25,7 @@
       target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
     }
 
-    function inputText(text, target) {
+    function inputText(target, text) {
       for (var i = 0; i < text.length; i++) {
         inputChar(text[i], target);
       }
@@ -63,7 +63,7 @@
       describe('without value', () => {
         describe('with user input', () => {
           beforeEach(async() => {
-            inputText('1/1/2022', input);
+            inputText(input, '1/1/2022');
             hasInputValueChangedSpy.reset();
           });
 
@@ -92,7 +92,7 @@
 
       describe('with value', () => {
         beforeEach(async() => {
-          inputText('1/1/2022', input);
+          inputText(input, '1/1/2022');
           enter(input);
           valueChangedSpy.reset();
           hasInputValueChangedSpy.reset();
@@ -100,7 +100,7 @@
 
         describe('with user input', () => {
           beforeEach(async() => {
-            inputText('foo', input);
+            inputText(input, 'foo');
             hasInputValueChangedSpy.reset();
           });
 

--- a/test/events.html
+++ b/test/events.html
@@ -1,18 +1,17 @@
 <!doctype html>
 
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <title>vaadin-date-picker events tests</title>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-picker.html">
-  <link rel="import" href="helpers.html">
-  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 </head>
 
 <body>
-  <test-fixture id="datepicker-clear-button-visible">
+  <test-fixture id="datepicker">
     <template>
       <vaadin-date-picker clear-button-visible></vaadin-date-picker>
     </template>
@@ -20,45 +19,74 @@
   <script>
   describe('events', () => {
 
+    var target;
+
+    function inputChar(char) {
+      target.value += char;
+      MockInteractions.keyDownOn(target, char.charCodeAt(0));
+      target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+    }
+
+    function inputText(text) {
+      for (var i = 0; i < text.length; i++) {
+        inputChar(text[i]);
+      }
+    }
+
+    function arrowDown() {
+      MockInteractions.keyDownOn(target, 40);
+    }
+  
+    function enter() {
+      MockInteractions.pressEnter(target);
+    }
+
+    function space() {
+      MockInteractions.pressSpace(target);
+    }
+
+    function esc() {
+      MockInteractions.keyDownOn(target, 27, null, 'Escape');
+    }
+
     describe('has-input-value-changed event', () => {
+      let datePicker, clearButton, hasInputValueChangedSpy, valueChangedSpy;
+  
       beforeEach(async() => {
         hasInputValueChangedSpy = sinon.spy();
         valueChangedSpy = sinon.spy();
-        datePicker = fixture('datepicker-clear-button-visible');
-        input = datePicker._inputElement;
-        clearButton = input.shadowRoot.querySelector('[part="clear-button"]');
+        datePicker = fixture('datepicker');
+        target = datePicker._inputElement;
+        clearButton = target.shadowRoot.querySelector('[part="clear-button"]');
         datePicker.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
         datePicker.addEventListener('value-changed', valueChangedSpy);
-        input.focus();
       });
 
       describe('without value', () => {
         describe('with user input', () => {
           beforeEach(async() => {
-            type('1/1/2022', input);
+            inputText('1/1/2022');
             hasInputValueChangedSpy.reset();
-            // valueChangedSpy.reset();
           });
 
           it('should be fired when clearing the user input with Esc', async() => {
-            pressEsc(input);
+            esc();
             expect(datePicker._inputElement.value).to.be.empty;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
           });
 
           it('should be fired when comitting the user input with Enter', async() => {
-            // pressEnter(input);
-            MockInteractions.pressEnter(input);
+            enter();
             expect(valueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
           });
 
           it('should be fired when selecting a date with Space', async() => {
-            // Move focus inside the dropdown to the typed date.
-            pressArrowDown(input);
-            pressSpace(input);
-            // expect(valueChangedSpy.calledOnce).to.be.true;
+            arrowDown();
+            target = datePicker._overlayContent;
+            space();
+            expect(valueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledOnce).to.be.true;
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
           });
@@ -67,16 +95,15 @@
 
       describe('with value', () => {
         beforeEach(async() => {
-          type('1/1/2022', input);
-          // pressEnter(input);
-          MockInteractions.pressEnter(input);
+          inputText('1/1/2022');
+          enter();
           valueChangedSpy.reset();
           hasInputValueChangedSpy.reset();
         });
 
         describe('with user input', () => {
           beforeEach(async() => {
-            type('foo', input);
+            inputText('foo');
             hasInputValueChangedSpy.reset();
           });
 
@@ -88,16 +115,14 @@
             expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
           });
 
-          /* it('should be fired when reverting the user input to the value with Esc', async () => {
-            	expect(datePicker._inputElement.value).to.equal('1/1/2022foo');
-            	pressEsc(input);
-                expect(datePicker._inputElement.value).to.equal('1/1/2022');
-                expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-              }); */
+          it('should be fired when reverting the user input to the value with Esc', async() => {
+            target = datePicker._overlayContent;
+            esc();
+            expect(datePicker._inputElement.value).to.equal('1/1/2022');
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          });
         });
       });
-
-  
     });
   });
   </script>

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -10,5 +10,38 @@
       Polymer.RenderStatus.afterNextRender(element, resolve);
     });
   };
+
+  function type(sequence, input) {
+    input.value += sequence;
+    input.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+  }
+  
+  function pressEsc(input) {
+    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
+    event.keyCode = 27;
+    event.code = 27;
+    input.dispatchEvent(event);
+  }
+
+  function pressEnter(input) {
+    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
+    event.keyCode = 13;
+    event.code = 13;
+    input.dispatchEvent(event);
+  }
+
+  function pressArrowDown(input) {
+    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
+    event.keyCode = 40;
+    event.code = 40;
+    input.dispatchEvent(event);
+  }
+
+  function pressSpace(input) {
+    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
+    event.keyCode = 32;
+    event.code = 32;
+    input.dispatchEvent(event);
+  }
 </script>
 </body>

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -10,38 +10,5 @@
       Polymer.RenderStatus.afterNextRender(element, resolve);
     });
   };
-
-  function type(sequence, input) {
-    input.value += sequence;
-    input.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
-  }
-  
-  function pressEsc(input) {
-    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
-    event.keyCode = 27;
-    event.code = 27;
-    input.dispatchEvent(event);
-  }
-
-  function pressEnter(input) {
-    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
-    event.keyCode = 13;
-    event.code = 13;
-    input.dispatchEvent(event);
-  }
-
-  function pressArrowDown(input) {
-    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
-    event.keyCode = 40;
-    event.code = 40;
-    input.dispatchEvent(event);
-  }
-
-  function pressSpace(input) {
-    const event = new CustomEvent('keydown', {bubbles: true, composed: true});
-    event.keyCode = 32;
-    event.code = 32;
-    input.dispatchEvent(event);
-  }
 </script>
 </body>


### PR DESCRIPTION
## Description

Backports the following PRs:

- https://github.com/vaadin/web-components/pull/5625

Part of https://github.com/vaadin/web-components/issues/5763